### PR TITLE
Clean exports from typer, remove unneeded Click components

### DIFF
--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -4,14 +4,7 @@ __version__ = "0.0.4"
 
 from click.exceptions import (  # noqa
     Abort,
-    BadArgumentUsage,
-    BadOptionUsage,
-    BadParameter,
-    ClickException,
-    FileError,
-    MissingParameter,
-    NoSuchOption,
-    UsageError,
+    Exit,
 )
 from click.termui import (  # noqa
     clear,
@@ -33,7 +26,6 @@ from click.utils import (  # noqa
     format_filename,
     get_app_dir,
     get_binary_stream,
-    get_os_args,
     get_text_stream,
     open_file,
 )

--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -2,10 +2,7 @@
 
 __version__ = "0.0.4"
 
-from click.exceptions import (  # noqa
-    Abort,
-    Exit,
-)
+from click.exceptions import Abort, Exit  # noqa
 from click.termui import (  # noqa
     clear,
     confirm,


### PR DESCRIPTION
:fire: Clean exports from typer, remove unneeded Click components and add `Exit` exception to simplify usage.