### PR TITLE
Fix enum options default not None

### DIFF
--- a/tests/test_tutorial/test_parameter_types/test_enum/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_enum/test_tutorial001.py
@@ -32,6 +32,12 @@ def test_invalid():
     )
 
 
+def test_no_options_is_default():
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert "Training neural network of type: simple" in result.output
+
+
 def test_script():
     result = subprocess.run(
         ["coverage", "run", mod.__file__, "--help"],

--- a/typer/main.py
+++ b/typer/main.py
@@ -454,7 +454,10 @@ def generate_enum_convertor(enum: Type[Enum]) -> Callable:
 
     def convertor(value: Any) -> Any:
         if value is not None:
-            low = str(value).lower()
+            if isinstance(value, Enum):
+                low = str(value.value).lower()
+            else:
+                low = str(value).lower()
             if low in lower_val_map:
                 key = lower_val_map[low]
                 return enum(key)


### PR DESCRIPTION
fixes #46 

* converter checks if value is Enum type and gets enum.value, or is string 
* New test to check default is correctly selected when option not provided