### PR TITLE
:pencil2: fix typo in progressbar/tutorial004.py

### DIFF
--- a/docs/src/progressbar/tutorial004.py
+++ b/docs/src/progressbar/tutorial004.py
@@ -9,7 +9,7 @@ def main():
         for batch in range(4):
             # Fake processing time
             time.sleep(1)
-            progress.update(2500)
+            progress.update(250)
     typer.echo(f"Processed {total} things in batches.")
 
 


### PR DESCRIPTION
In the tutorial, the length of the progress bar is set to 1000 and the update was mistakenly set to 2500. The update should be 1/4 of the length given that the loop runs for 4 iterations. This commit sets the update amount to 250 which better showcases the feature.