### PR TITLE
[TYPO] Change bashrc to zshrc in example for zsh completion

### DIFF
--- a/docs/tutorial/package.md
+++ b/docs/tutorial/package.md
@@ -77,7 +77,7 @@ Package operations: 15 installs, 0 updates, 0 removals
   - Installing py (1.8.1)
   - Installing shellingham (1.3.2)
   - Installing wcwidth (0.1.8)
-  - Installing pytest (5.4.1)
+  - Installing pytest (5.3.5)
   - Installing typer (0.0.11)
 
 // Activate that new virtual environment

--- a/docs/typer-cli.md
+++ b/docs/typer-cli.md
@@ -94,7 +94,7 @@ You can then install completion for it:
 ```console
 $ typer --install-completion
 
-zsh completion installed in /home/user/.bashrc.
+zsh completion installed in /home/user/.zshrc.
 Completion will take effect once you restart the terminal.
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,11 @@ Documentation = "https://typer.tiangolo.com/"
 [tool.flit.metadata.requires-extra]
 test = [
     "shellingham",
-    "pytest >=4.4.0",
+    "pytest >=4.4.0,<5.4.0",
     "pytest-cov",
     "coverage",
     "pytest-xdist",
-    "pytest-sugar",
+    "pytest-sugar",  # Broken with pytest 5.4.X until https://github.com/Teemu/pytest-sugar/pull/188 released
     "mypy",
     "black",
     "isort"


### PR DESCRIPTION
Looks like there was a typo in the example for `typer-cli`. zsh completion wouldn't be installed in `~/.bashrc`.