### PR TITLE
Minor correction in CLI Arguments page

### DIFF
--- a/docs/tutorial/arguments.md
+++ b/docs/tutorial/arguments.md
@@ -203,6 +203,6 @@ You should document your *CLI arguments* the same way.
 
 ## Other uses
 
-`typer.Argument()` has several other users. For data validation, to enable other features, etc.
+`typer.Argument()` has several other use-cases; for data validation, to enable
 
-But you will see about that later in the docs.
+other features, etc. You will learn about these later in the docs.


### PR DESCRIPTION
Minor correction in the CLI Arguments tutorial page. Changed users to use-cases under other uses section. 