### PR TITLE
➕ Added support for datetime.date CLI argument

### DIFF
--- a/typer/main.py
+++ b/typer/main.py
@@ -1,5 +1,5 @@
+import datetime
 import inspect
-from datetime import datetime
 from enum import Enum
 from functools import update_wrapper
 from pathlib import Path
@@ -528,7 +528,7 @@ def get_click_type(
         return click.BOOL
     elif annotation == UUID:
         return click.UUID
-    elif annotation == datetime:
+    elif annotation == datetime.datetime or annotation == datetime.date:
         return click.DateTime(formats=parameter_info.formats)
     elif (
         annotation == Path


### PR DESCRIPTION
Adding support for arguments with type `datetime.date` as requested from [Issue #94](https://github.com/tiangolo/typer/issues/94)

By changing the import from `from datetime import datetime` to `import datetime` ( [see this stack overflow thread on it](https://stackoverflow.com/questions/16151402/python-how-can-i-check-whether-an-object-is-of-type-datetime-date) ) and by checking if the annotation type was either `datetime.datetime` or `datetime.date` we can support the new type. 

Not sure if this was a design decision to not include datetime.date but if it wasn't then I hope I've helped out even if it was only 2 lines. If I did anything drastically wrong please let me know.

All tests (`bash scripts/test-cov-html.sh`) pass with 100% coverage so nothing seems broken

This script which was given in the issue now works: 
```python
# example.py
import datetime
import typer

def do_thing_with_date(date: datetime.date):
    typer.echo(f"Year is: {date.year}")

if __name__ == "__main__":
    typer.run(do_thing_with_date)
```