### PR TITLE
Add note on develop install. Add means of simply running subcommand program using typer.run

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,27 @@ And that will:
 * Add two subcommands with `@app.command()`.
 * Execute the `app()` itself, as if it was a function (instead of `typer.run`).
 
+Alternatively, you can simply do
+
+```Python hl_lines="3  6  11  20"
+import typer
+
+
+def hello(name: str):
+    typer.echo(f"Hello {name}")
+
+
+def goodbye(name: str, formal: bool = False):
+    if formal:
+        typer.echo(f"Goodbye Ms. {name}. Have a good day.")
+    else:
+        typer.echo(f"Bye {name}!")
+
+
+if __name__ == "__main__":
+    typer.run(hello, goodbye)
+```
+
 ### Run the upgraded example
 
 <div class="termy">

--- a/README.md
+++ b/README.md
@@ -280,6 +280,17 @@ But you can also install extras:
 
 You can install `typer` with `colorama` and `shellingham` with `pip install typer[all]`.
 
+## Develop install
+
+You can develop install using `flit`:
+
+```Bash
+    pip install flit
+    flit install --pth-file
+```
+
+This is analagous to `python setup.py develop`.
+
 ## Other tools and plug-ins
 
 Click has many plug-ins available that you can use. And there are many tools that help with command line applications that you can use as well, even if they are not related to Typer or Click.

--- a/typer/main.py
+++ b/typer/main.py
@@ -849,7 +849,8 @@ def get_param_completion(callback: Optional[Callable] = None) -> Optional[Callab
     return wrapper
 
 
-def run(function: Callable) -> Any:
+def run(*function: List[Callable]) -> Any:
     app = Typer()
-    app.command()(function)
+    for fun in function:
+        app.command()(fun)
     app()


### PR DESCRIPTION
The linter is failing and I don't underestand it. Otherwise probably fine.

I was looking for something to replace `argh` library and thought this one was closest. It is very important to have the option to not touch the functions (no decoration on import) so that these libraries have the option of being completely unused in the case of no `if __name__ == '__main__':`.

You can even bury the import of typer in the ```if __name__``` block if you really wanted to make the CLI optional for some library.