### PR TITLE
use value.name as input value for enums

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-
-source =
-    typer
-    tests
-    docs_src
-
-parallel = True

--- a/typer/main.py
+++ b/typer/main.py
@@ -451,7 +451,7 @@ def param_path_convertor(value: Optional[str] = None) -> Optional[Path]:
 
 
 def generate_enum_convertor(enum: Type[Enum]) -> Callable:
-    lower_val_map = {str(val.value).lower(): val for val in enum}
+    lower_val_map = {str(val.name).lower(): val for val in enum}
 
     def convertor(value: Any) -> Any:
         if value is not None:
@@ -581,7 +581,7 @@ def get_click_type(
         )
     elif lenient_issubclass(annotation, Enum):
         return click.Choice(
-            [item.value for item in annotation],
+            [item.name for item in annotation],
             case_sensitive=parameter_info.case_sensitive,
         )
     raise RuntimeError(f"Type not yet supported: {annotation}")  # pragma no cover


### PR DESCRIPTION
This is a pull request related to https://github.com/tiangolo/typer/issues/151

I did not change the value provided to the function (still an instance of the Enum class, not `value.value` as stated in the issue).
If you are ok with these changes I will try to update the documentation as well.