### PR TITLE
Coroutine command support through asyncio

### DIFF
--- a/typer/main.py
+++ b/typer/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 from datetime import datetime
 from enum import Enum
@@ -211,7 +212,11 @@ class Typer:
         )
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        return get_command(self)(*args, **kwargs)
+        command = get_command(self)
+        if asyncio.iscoroutinefunction(command):
+            return asyncio.run(command)
+        else:
+            return command(*args, **kwargs)
 
 
 def get_group(typer_instance: Typer) -> click.Command:


### PR DESCRIPTION
Hello and first of all, thanks for all the wonderful typed stack you offer ! FastAPI and Typer are nothing but badass.

Maybe this PR doesn't make sense in which case I will close it, the idea is to offer support of _async function_ decorated with `command()`. Unless I didn't figure out another way to do it but I feel like currently if you want to use coroutine into your command function you need to explicitly run an event loop yourself inside your command. It would be nice to just define our command as _async function_ directly and Typer would take care of the rest as it is done in FastAPI.

To do so I just propose to update the `__call__` operator overload and add a simple introspection control to see if the registered command is a coroutine function in which case it will be called using `asyncio.run`. I don't think supporting other concurrent framework such as `Twisted` would make sense in a CLI application but it could be also considered in a next iteration ?

If all this sound appropriate then I will update this PR to include unit test as well as some additional documentation to highlight the asynchronous support. Also feel free to suggest other way to approach this problem in which case I will update the implementation accordingly :)