### PR TITLE
Convert default values for datetime option to str

### DIFF
--- a/typer/main.py
+++ b/typer/main.py
@@ -614,6 +614,9 @@ def get_click_param(
     else:
         default_value = param.default
         parameter_info = OptionInfo()
+    # Click expects a str for DateTime input so convert default value to ISO string
+    if isinstance(default_value, datetime):
+        default_value = default_value.isoformat()        
     annotation: Any = Any
     if not param.annotation == param.empty:
         annotation = param.annotation


### PR DESCRIPTION
If you specify a default value for a DateTime Option of type datetime, click will throw an error.
This converts it to a string first, so that click can then convert it back to a datetime again. 

Fixes Issue #215 [BUG] Default datetime must be string