### PR TITLE
Improve testing stderr tip.

### DIFF
--- a/docs/tutorial/testing.md
+++ b/docs/tutorial/testing.md
@@ -70,7 +70,7 @@ Here we are checking that the exit code is 0, as it is for programs that exit wi
 Then we check that the text printed to "standard output" contains the text that our CLI program prints.
 
 !!! tip
-    You could also check `result.stderr` for "standard error".
+    You could also check `result.stderr` for "standard error", but you will have to tell the runner to capture it separately `CliRunner(mix_stderr=False)`
 
 !!! info
     If you need a refresher about what is "standard output" and "standard error" check the section in [Printing and Colors: "Standard Output" and "Standard Error"](printing.md#standard-output-and-standard-error){.internal-link target=_blank}.


### PR DESCRIPTION
It wasn't at all obvious to me that the error I got was not from my code or pytest, but  from Typer.
Preferrably I'd put something like 'pass mix_stderr=False to CliRunner' in the error message, and keep the tip short. But I couldn't find it quickly. I think it's upstream in the Click runner.