### PR TITLE
Add click 8.1.0 support

### DIFF
--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -2,6 +2,8 @@
 
 __version__ = "0.4.0"
 
+from shutil import get_terminal_size as get_terminal_size
+
 from click.exceptions import Abort as Abort
 from click.exceptions import BadParameter as BadParameter
 from click.exceptions import Exit as Exit
@@ -9,7 +11,6 @@ from click.termui import clear as clear
 from click.termui import confirm as confirm
 from click.termui import echo_via_pager as echo_via_pager
 from click.termui import edit as edit
-from click.termui import get_terminal_size as get_terminal_size
 from click.termui import getchar as getchar
 from click.termui import launch as launch
 from click.termui import pause as pause


### PR DESCRIPTION
Some deprecated code was removed in https://github.com/pallets/click/pull/2130 resulting in the failed import of `get_terminal_size` from `click`. Per the recommendation in Click's release notes, we can import from `shutil` instead.

`get_terminal_size` can probably be dropped from Typer's interface in the future since it's been dropped from Click's, but I'll leave that decision to a future PR. This change is backwards compatible.

See https://click.palletsprojects.com/en/8.1.x/changes/#version-8-1-0
Closes https://github.com/tiangolo/typer/issues/377
