### PR TITLE
Import get_terminal_size from shutil

### DIFF
--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -9,7 +9,6 @@ from click.termui import clear as clear
 from click.termui import confirm as confirm
 from click.termui import echo_via_pager as echo_via_pager
 from click.termui import edit as edit
-from click.termui import get_terminal_size as get_terminal_size
 from click.termui import getchar as getchar
 from click.termui import launch as launch
 from click.termui import pause as pause
@@ -24,6 +23,7 @@ from click.utils import get_app_dir as get_app_dir
 from click.utils import get_binary_stream as get_binary_stream
 from click.utils import get_text_stream as get_text_stream
 from click.utils import open_file as open_file
+from shutil import get_terminal_size as get_terminal_size
 
 from . import colors as colors
 from .main import Typer as Typer


### PR DESCRIPTION
`get_terminal_size`  function has been removed from Click 8.1.0. We should use `shutil.get_terminal_size` instead.

This change is required to handle the following error when using spaCy 3.2.3.

```
ImportError: cannot import name 'get_terminal_size' from 'click.termui'
```