### PR TITLE
Add documentation for enums created via the functional API

### DIFF
--- a/docs/tutorial/parameter-types/enum.md
+++ b/docs/tutorial/parameter-types/enum.md
@@ -66,3 +66,16 @@ Training neural network of type: lstm
 ```
 
 </div>
+
+
+### Functional API
+
+In order to use an `Enum` created using the <a href="https://docs.python.org/3/library/enum.html#functional-api" class="external-link" target="_blank">functional API</a>, you need to create an enum with string values.
+
+You also need to supply the default value as a string (not the enum):
+
+```Python hl_lines="5 9"
+{!../docs_src/parameter_types/enum/tutorial003.py!}
+```
+
+Alternatively, you can create an `Enum` that extends both `str` and `Enum`. In Python 3.11+, there is <a href="https://docs.python.org/3.11/library/enum.html#enum.StrEnum" class="external-link" target="_blank">`enum.StrEnum`</a>. For Python 3.10 or earlier, there is the <a href="https://github.com/irgeek/StrEnum" class="external-link" target="_blank">StrEnum package</a>.

--- a/docs_src/parameter_types/enum/tutorial003.py
+++ b/docs_src/parameter_types/enum/tutorial003.py
@@ -1,0 +1,18 @@
+from enum import Enum
+
+import typer
+
+NeuralNetwork = Enum(
+    "NeuralNetwork",
+    {k: k for k in ["simple", "conv", "lstm"]}
+)
+
+
+def main(
+    network: NeuralNetwork = typer.Option("simple", case_sensitive=False)
+):
+    typer.echo(f"Training neural network of type: {network.value}")
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
This PR updates the documentation to include discussion of enumerating choices with `enum.Enum`s created with the functional API. This is useful when creating choices dynamically, for example logging.

See further discussion of enums and the functional API in https://github.com/tiangolo/typer/issues/389