### PR TITLE
👷‍♂️ Ensure the `PYTHONPATH` is set properly when testing the tutorial scripts

### DIFF
--- a/tests/test_tutorial/test_subcommands/test_tutorial001.py
+++ b/tests/test_tutorial/test_subcommands/test_tutorial001.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 import pytest
@@ -84,11 +85,15 @@ def test_users_delete(app):
 def test_scripts(mod):
     from docs_src.subcommands.tutorial001 import items, users
 
+    env = os.environ.copy()
+    env["PYTHONPATH"] = ":".join(list(tutorial001.__path__))
+
     for module in [mod, items, users]:
         result = subprocess.run(
             ["coverage", "run", module.__file__, "--help"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",
+            env=env,
         )
         assert "Usage" in result.stdout

--- a/tests/test_tutorial/test_subcommands/test_tutorial003.py
+++ b/tests/test_tutorial/test_subcommands/test_tutorial003.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 import pytest
@@ -157,11 +158,15 @@ def test_lands_towns_burn(app):
 def test_scripts(mod):
     from docs_src.subcommands.tutorial003 import items, lands, reigns, towns, users
 
+    env = os.environ.copy()
+    env["PYTHONPATH"] = ":".join(list(tutorial003.__path__))
+
     for module in [mod, items, lands, reigns, towns, users]:
         result = subprocess.run(
             ["coverage", "run", module.__file__, "--help"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",
+            env=env,
         )
         assert "Usage" in result.stdout


### PR DESCRIPTION
When packaging Typer for openSUSE I ran into errors because the tutorial
scripts were unable to import their colocated modules. Curiously this
only seems to be occurring when these scripts are run via coverage, as
they are in the tests. Them being run via coverage however also prevents
just changing the working directory for the script runs, as then the
coverage file would end up in the wrong directory.

Curiously, I have not been able to reproduce this issue on openSUSE Leap
but only seen it on openSUSE Tumbleweed. Thus, there might be something
weird with the Python stack or the coverage version on Tumbleweed.
However, as the same PYTHONPATH-patching is also done for the tests of
the tutorial code that run it directly and not as a subprocess, I think
it is just consistent to also do this for the script test. Thus, please view this PR
as a suggestion that improves consistency. If you think it does not provide
value outside of my very specific use-case, I am completely fine with it being
declined.

For reference, this is the error that I am observing in the packaging
environment and that gets resolved by this commit:

[  123s] =================================== FAILURES ===================================
[  123s] _________________________________ test_scripts _________________________________
[  123s]
[  123s] mod = <module 'docs_src.subcommands.tutorial001.main' from '/home/abuild/rpmbuild/BUILD/typer-0.4.1/docs_src/subcommands/tutorial001/main.py'>
[  123s]
[  123s]     def test_scripts(mod):
[  123s]         from docs_src.subcommands.tutorial001 import items, users
[  123s]
[  123s]         for module in [mod, items, users]:
[  123s]             result = subprocess.run(
[  123s]                 ["coverage", "run", module.__file__, "--help"],
[  123s]                 stdout=subprocess.PIPE,
[  123s]                 stderr=subprocess.PIPE,
[  123s]                 encoding="utf-8",
[  123s]             )
[  123s] >           assert "Usage" in result.stdout
[  123s] E           assert 'Usage' in ''
[  123s] E            +  where '' = CompletedProcess(args=['coverage', 'run', '/home/abuild/rpmbuild/BUILD/typer-0.4.1/docs_src/subcommands/tutorial001/main.py', '--help'], returncode=1, stdout='', stderr='Traceback (most recent call last):\n  File "/home/abuild/rpmbuild/BUILD/typer-0.4.1/docs_src/subcommands/tutorial001/main.py", line 3, in <module>\n    import items\nModuleNotFoundError: No module named \'items\'\n').stdout
[  123s]
[  123s] tests/test_tutorial/test_subcommands/test_tutorial001.py:94: AssertionError
[  123s] _________________________________ test_scripts _________________________________
[  123s]
[  123s] mod = <module 'docs_src.subcommands.tutorial003.main' from '/home/abuild/rpmbuild/BUILD/typer-0.4.1/docs_src/subcommands/tutorial003/main.py'>
[  123s]
[  123s]     def test_scripts(mod):
[  123s]         from docs_src.subcommands.tutorial003 import items, lands, reigns, towns, users
[  123s]
[  123s]         for module in [mod, items, lands, reigns, towns, users]:
[  123s]             result = subprocess.run(
[  123s]                 ["coverage", "run", module.__file__, "--help"],
[  123s]                 stdout=subprocess.PIPE,
[  123s]                 stderr=subprocess.PIPE,
[  123s]                 encoding="utf-8",
[  123s]             )
[  123s] >           assert "Usage" in result.stdout
[  123s] E           assert 'Usage' in ''
[  123s] E            +  where '' = CompletedProcess(args=['coverage', 'run', '/home/abuild/rpmbuild/BUILD/typer-0.4.1/docs_src/subcommands/tutorial003/main.py', '--help'], returncode=1, stdout='', stderr='Traceback (most recent call last):\n  File "/home/abuild/rpmbuild/BUILD/typer-0.4.1/docs_src/subcommands/tutorial003/main.py", line 3, in <module>\n    import items\nModuleNotFoundError: No module named \'items\'\n').stdout
[  123s]
[  123s] tests/test_tutorial/test_subcommands/test_tutorial003.py:146: AssertionError