### PR TITLE
👷‍♂️ Consistently use `sys.executable` to run subprocesses, needed by OpenSUSE

### DIFF
--- a/tests/test_compat/test_option_get_help.py
+++ b/tests/test_compat/test_option_get_help.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 import typer.core
 from typer.testing import CliRunner
@@ -40,7 +41,7 @@ def test_coverage_call():
 
 def test_completion():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_completion/test_completion.py
+++ b/tests/test_completion/test_completion.py
@@ -47,7 +47,7 @@ def test_install_completion():
 
 def test_completion_invalid_instruction():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__],
+        [sys.executable, "-m", "coverage", "run", mod.__file__],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -63,7 +63,7 @@ def test_completion_invalid_instruction():
 
 def test_completion_source_bash():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__],
+        [sys.executable, "-m", "coverage", "run", mod.__file__],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -81,7 +81,7 @@ def test_completion_source_bash():
 
 def test_completion_source_invalid_shell():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__],
+        [sys.executable, "-m", "coverage", "run", mod.__file__],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -96,7 +96,7 @@ def test_completion_source_invalid_shell():
 
 def test_completion_source_invalid_instruction():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__],
+        [sys.executable, "-m", "coverage", "run", mod.__file__],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -111,7 +111,7 @@ def test_completion_source_invalid_instruction():
 
 def test_completion_source_zsh():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__],
+        [sys.executable, "-m", "coverage", "run", mod.__file__],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -126,7 +126,7 @@ def test_completion_source_zsh():
 
 def test_completion_source_fish():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__],
+        [sys.executable, "-m", "coverage", "run", mod.__file__],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -141,7 +141,7 @@ def test_completion_source_fish():
 
 def test_completion_source_powershell():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__],
+        [sys.executable, "-m", "coverage", "run", mod.__file__],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -159,7 +159,7 @@ def test_completion_source_powershell():
 
 def test_completion_source_pwsh():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__],
+        [sys.executable, "-m", "coverage", "run", mod.__file__],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_completion/test_completion_complete.py
+++ b/tests/test_completion/test_completion_complete.py
@@ -1,12 +1,13 @@
 import os
 import subprocess
+import sys
 
 from docs_src.commands.help import tutorial001 as mod
 
 
 def test_completion_complete_subcommand_bash():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -23,7 +24,7 @@ def test_completion_complete_subcommand_bash():
 
 def test_completion_complete_subcommand_bash_invalid():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -40,7 +41,7 @@ def test_completion_complete_subcommand_bash_invalid():
 
 def test_completion_complete_subcommand_zsh():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -59,7 +60,7 @@ def test_completion_complete_subcommand_zsh():
 
 def test_completion_complete_subcommand_zsh_files():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -75,7 +76,7 @@ def test_completion_complete_subcommand_zsh_files():
 
 def test_completion_complete_subcommand_fish():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -95,7 +96,7 @@ def test_completion_complete_subcommand_fish():
 
 def test_completion_complete_subcommand_fish_should_complete():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -112,7 +113,7 @@ def test_completion_complete_subcommand_fish_should_complete():
 
 def test_completion_complete_subcommand_fish_should_complete_no():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -129,7 +130,7 @@ def test_completion_complete_subcommand_fish_should_complete_no():
 
 def test_completion_complete_subcommand_powershell():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -147,7 +148,7 @@ def test_completion_complete_subcommand_powershell():
 
 def test_completion_complete_subcommand_pwsh():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -165,7 +166,7 @@ def test_completion_complete_subcommand_pwsh():
 
 def test_completion_complete_subcommand_noshell():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_completion/test_completion_complete_no_help.py
+++ b/tests/test_completion/test_completion_complete_no_help.py
@@ -1,12 +1,13 @@
 import os
 import subprocess
+import sys
 
 from docs_src.commands.index import tutorial002 as mod
 
 
 def test_completion_complete_subcommand_zsh():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -23,7 +24,7 @@ def test_completion_complete_subcommand_zsh():
 
 def test_completion_complete_subcommand_fish():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -40,7 +41,7 @@ def test_completion_complete_subcommand_fish():
 
 def test_completion_complete_subcommand_powershell():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -56,7 +57,7 @@ def test_completion_complete_subcommand_powershell():
 
 def test_completion_complete_subcommand_pwsh():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_completion/test_completion_install.py
+++ b/tests/test_completion/test_completion_install.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from pathlib import Path
 from unittest import mock
 
@@ -16,7 +17,7 @@ app.command()(mod.main)
 
 def test_completion_install_no_shell():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--install-completion"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--install-completion"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -39,7 +40,15 @@ def test_completion_install_bash():
     if bash_completion_path.is_file():
         text = bash_completion_path.read_text()
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--install-completion", "bash"],
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            mod.__file__,
+            "--install-completion",
+            "bash",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -74,7 +83,15 @@ def test_completion_install_zsh():
     if completion_path.is_file():
         text = completion_path.read_text()
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--install-completion", "zsh"],
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            mod.__file__,
+            "--install-completion",
+            "zsh",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -103,7 +120,15 @@ def test_completion_install_fish():
         Path.home() / f".config/fish/completions/{script_path.name}.fish"
     )
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--install-completion", "fish"],
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            mod.__file__,
+            "--install-completion",
+            "fish",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_completion/test_completion_show.py
+++ b/tests/test_completion/test_completion_show.py
@@ -1,12 +1,13 @@
 import os
 import subprocess
+import sys
 
 from docs_src.commands.index import tutorial001 as mod
 
 
 def test_completion_show_no_shell():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--show-completion"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--show-completion"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -25,7 +26,15 @@ def test_completion_show_no_shell():
 
 def test_completion_show_bash():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--show-completion", "bash"],
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            mod.__file__,
+            "--show-completion",
+            "bash",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -43,7 +52,15 @@ def test_completion_show_bash():
 
 def test_completion_source_zsh():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--show-completion", "zsh"],
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            mod.__file__,
+            "--show-completion",
+            "zsh",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -58,7 +75,15 @@ def test_completion_source_zsh():
 
 def test_completion_source_fish():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--show-completion", "fish"],
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            mod.__file__,
+            "--show-completion",
+            "fish",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -73,7 +98,15 @@ def test_completion_source_fish():
 
 def test_completion_source_powershell():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--show-completion", "powershell"],
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            mod.__file__,
+            "--show-completion",
+            "powershell",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -91,7 +124,15 @@ def test_completion_source_powershell():
 
 def test_completion_source_pwsh():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--show-completion", "pwsh"],
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            mod.__file__,
+            "--show-completion",
+            "pwsh",
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from pathlib import Path
 from unittest import mock
 
@@ -97,7 +98,7 @@ def test_callback_3_untyped_parameters():
 def test_completion_untyped_parameters():
     file_path = Path(__file__).parent / "assets/completion_no_types.py"
     result = subprocess.run(
-        ["coverage", "run", str(file_path)],
+        [sys.executable, "-m", "coverage", "run", str(file_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -119,7 +120,7 @@ def test_completion_untyped_parameters():
     assert '"Carlos":"The writer of scripts."' in result.stdout
 
     result = subprocess.run(
-        ["coverage", "run", str(file_path)],
+        [sys.executable, "-m", "coverage", "run", str(file_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -130,7 +131,7 @@ def test_completion_untyped_parameters():
 def test_completion_untyped_parameters_different_order_correct_names():
     file_path = Path(__file__).parent / "assets/completion_no_types_order.py"
     result = subprocess.run(
-        ["coverage", "run", str(file_path)],
+        [sys.executable, "-m", "coverage", "run", str(file_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -152,7 +153,7 @@ def test_completion_untyped_parameters_different_order_correct_names():
     assert '"Carlos":"The writer of scripts."' in result.stdout
 
     result = subprocess.run(
-        ["coverage", "run", str(file_path)],
+        [sys.executable, "-m", "coverage", "run", str(file_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_prog_name.py
+++ b/tests/test_prog_name.py
@@ -1,11 +1,12 @@
 import subprocess
+import sys
 from pathlib import Path
 
 
 def test_custom_prog_name():
     file_path = Path(__file__).parent / "assets/prog_name.py"
     result = subprocess.run(
-        ["coverage", "run", str(file_path), "--help"],
+        [sys.executable, "-m", "coverage", "run", str(file_path), "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tracebacks.py
+++ b/tests/test_tracebacks.py
@@ -1,12 +1,13 @@
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 
 def test_traceback_no_rich():
     file_path = Path(__file__).parent / "assets/type_error_no_rich.py"
     result = subprocess.run(
-        ["coverage", "run", str(file_path)],
+        [sys.executable, "-m", "coverage", "run", str(file_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -26,7 +27,7 @@ def test_traceback_no_rich():
 def test_traceback_no_rich_short_disable():
     file_path = Path(__file__).parent / "assets/type_error_no_rich_short_disable.py"
     result = subprocess.run(
-        ["coverage", "run", str(file_path)],
+        [sys.executable, "-m", "coverage", "run", str(file_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -46,7 +47,7 @@ def test_traceback_no_rich_short_disable():
 def test_unmodified_traceback():
     file_path = Path(__file__).parent / "assets/type_error_normal_traceback.py"
     result = subprocess.run(
-        ["coverage", "run", str(file_path)],
+        [sys.executable, "-m", "coverage", "run", str(file_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_default/test_tutorial001.py
+++ b/tests/test_tutorial/test_arguments/test_default/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -33,7 +34,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_default/test_tutorial002.py
+++ b/tests/test_tutorial/test_arguments/test_default/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -35,7 +36,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_envvar/test_tutorial001.py
+++ b/tests/test_tutorial/test_arguments/test_envvar/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 import typer.core
@@ -53,7 +54,7 @@ def test_call_env_var_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_envvar/test_tutorial002.py
+++ b/tests/test_tutorial/test_arguments/test_envvar/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -40,7 +41,7 @@ def test_call_env_var2():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_envvar/test_tutorial003.py
+++ b/tests/test_tutorial/test_arguments/test_envvar/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -40,7 +41,7 @@ def test_call_env_var_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial001.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 import typer.core
@@ -43,7 +44,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial002.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -30,7 +31,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial003.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -30,7 +31,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial004.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial004.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -30,7 +31,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial005.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial005.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -28,7 +29,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial006.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial006.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -28,7 +29,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial007.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial007.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 import typer.core
@@ -28,7 +29,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial008.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial008.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 import typer.core
@@ -41,7 +42,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_optional/test_tutorial001.py
+++ b/tests/test_tutorial/test_arguments/test_optional/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 import typer.core
@@ -42,7 +43,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_arguments/test_optional/test_tutorial002.py
+++ b/tests/test_tutorial/test_arguments/test_optional/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -31,7 +32,7 @@ def test_call_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_arguments/test_tutorial001.py
+++ b/tests/test_tutorial/test_commands/test_arguments/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -35,7 +36,7 @@ def test_delete():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_callback/test_tutorial001.py
+++ b/tests/test_tutorial/test_commands/test_callback/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer.core
 from typer.testing import CliRunner
@@ -71,7 +72,7 @@ def test_wrong_verbose():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_callback/test_tutorial002.py
+++ b/tests/test_tutorial/test_commands/test_callback/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -18,7 +19,7 @@ def test_app():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_callback/test_tutorial003.py
+++ b/tests/test_tutorial/test_commands/test_callback/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -23,7 +24,7 @@ def test_for_coverage():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_callback/test_tutorial004.py
+++ b/tests/test_tutorial/test_commands/test_callback/test_tutorial004.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -25,7 +26,7 @@ def test_app():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_context/test_tutorial001.py
+++ b/tests/test_tutorial/test_commands/test_context/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -25,7 +26,7 @@ def test_delete():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_context/test_tutorial002.py
+++ b/tests/test_tutorial/test_commands/test_context/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_callback():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_context/test_tutorial003.py
+++ b/tests/test_tutorial/test_commands/test_context/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_callback():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_context/test_tutorial004.py
+++ b/tests/test_tutorial/test_commands/test_context/test_tutorial004.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -20,7 +21,7 @@ def test_1():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial001.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -117,7 +118,7 @@ def test_init():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial002.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -48,7 +49,7 @@ def test_delete():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial003.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -36,7 +37,7 @@ def test_call():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial004.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial004.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -51,7 +52,7 @@ def test_delete():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial005.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial005.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -52,7 +53,7 @@ def test_delete():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial006.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial006.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -43,7 +44,7 @@ def test_call():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial007.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial007.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -47,7 +48,7 @@ def test_call():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial008.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial008.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -24,7 +25,7 @@ def test_call():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_index/test_tutorial001.py
+++ b/tests/test_tutorial/test_commands/test_index/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -23,7 +24,7 @@ def test_arg():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_index/test_tutorial002.py
+++ b/tests/test_tutorial/test_commands/test_index/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -32,7 +33,7 @@ def test_delete():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_name/test_tutorial001.py
+++ b/tests/test_tutorial/test_commands/test_name/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_delete():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_one_or_multiple/test_tutorial001.py
+++ b/tests/test_tutorial/test_commands/test_one_or_multiple/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -24,7 +25,7 @@ def test_command():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_one_or_multiple/test_tutorial002.py
+++ b/tests/test_tutorial/test_commands/test_one_or_multiple/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -26,7 +27,7 @@ def test_command():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_commands/test_options/test_tutorial001.py
+++ b/tests/test_tutorial/test_commands/test_options/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -88,7 +89,7 @@ def test_init():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_exceptions/test_tutorial001.py
+++ b/tests/test_tutorial/test_exceptions/test_tutorial001.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -12,7 +13,7 @@ runner = CliRunner()
 def test_traceback_rich():
     file_path = Path(mod.__file__)
     result = subprocess.run(
-        ["coverage", "run", str(file_path)],
+        [sys.executable, "-m", "coverage", "run", str(file_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -34,7 +35,7 @@ def test_traceback_rich():
 def test_standard_traceback_env_var():
     file_path = Path(mod.__file__)
     result = subprocess.run(
-        ["coverage", "run", str(file_path)],
+        [sys.executable, "-m", "coverage", "run", str(file_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -55,7 +56,7 @@ def test_standard_traceback_env_var():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_exceptions/test_tutorial002.py
+++ b/tests/test_tutorial/test_exceptions/test_tutorial002.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -12,7 +13,7 @@ runner = CliRunner()
 def test_traceback_rich():
     file_path = Path(mod.__file__)
     result = subprocess.run(
-        ["coverage", "run", str(file_path), "secret"],
+        [sys.executable, "-m", "coverage", "run", str(file_path), "secret"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -34,7 +35,7 @@ def test_traceback_rich():
 def test_standard_traceback_env_var():
     file_path = Path(mod.__file__)
     result = subprocess.run(
-        ["coverage", "run", str(file_path), "secret"],
+        [sys.executable, "-m", "coverage", "run", str(file_path), "secret"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -55,7 +56,7 @@ def test_standard_traceback_env_var():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_exceptions/test_tutorial003.py
+++ b/tests/test_tutorial/test_exceptions/test_tutorial003.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -12,7 +13,7 @@ runner = CliRunner()
 def test_traceback_rich_pretty_short_disable():
     file_path = Path(mod.__file__)
     result = subprocess.run(
-        ["coverage", "run", str(file_path)],
+        [sys.executable, "-m", "coverage", "run", str(file_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -33,7 +34,7 @@ def test_traceback_rich_pretty_short_disable():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_exceptions/test_tutorial004.py
+++ b/tests/test_tutorial/test_exceptions/test_tutorial004.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -12,7 +13,7 @@ runner = CliRunner()
 def test_rich_pretty_exceptions_disable():
     file_path = Path(mod.__file__)
     result = subprocess.run(
-        ["coverage", "run", str(file_path)],
+        [sys.executable, "-m", "coverage", "run", str(file_path)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -31,7 +32,7 @@ def test_rich_pretty_exceptions_disable():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_first_steps/test_tutorial001.py
+++ b/tests/test_tutorial/test_first_steps/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -17,7 +18,7 @@ def test_cli():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_first_steps/test_tutorial002.py
+++ b/tests/test_tutorial/test_first_steps/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -25,7 +26,7 @@ def test_2():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_first_steps/test_tutorial003.py
+++ b/tests/test_tutorial/test_first_steps/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -25,7 +26,7 @@ def test_2():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_first_steps/test_tutorial004.py
+++ b/tests/test_tutorial/test_first_steps/test_tutorial004.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -49,7 +50,7 @@ def test_formal_3():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_first_steps/test_tutorial005.py
+++ b/tests/test_tutorial/test_first_steps/test_tutorial005.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -49,7 +50,7 @@ def test_formal_1():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_first_steps/test_tutorial006.py
+++ b/tests/test_tutorial/test_first_steps/test_tutorial006.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -44,7 +45,7 @@ def test_formal_1():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_multiple_values/test_arguments_with_multiple_values/test_tutorial001.py
+++ b/tests/test_tutorial/test_multiple_values/test_arguments_with_multiple_values/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -19,7 +20,7 @@ def test_main():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_multiple_values/test_arguments_with_multiple_values/test_tutorial002.py
+++ b/tests/test_tutorial/test_multiple_values/test_arguments_with_multiple_values/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -47,7 +48,7 @@ def test_valid_args():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_multiple_values/test_multiple_options/test_tutorial001.py
+++ b/tests/test_tutorial/test_multiple_values/test_multiple_options/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -35,7 +36,7 @@ def test_3_user():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_multiple_values/test_multiple_options/test_tutorial002.py
+++ b/tests/test_tutorial/test_multiple_values/test_multiple_options/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -30,7 +31,7 @@ def test_2_number():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_multiple_values/test_options_with_multiple_values/test_tutorial001.py
+++ b/tests/test_tutorial/test_multiple_values/test_options_with_multiple_values/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -44,7 +45,7 @@ def test_invalid_user():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_callback/test_tutorial001.py
+++ b/tests/test_tutorial/test_options/test_callback/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -25,7 +26,7 @@ def test_2():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_callback/test_tutorial003.py
+++ b/tests/test_tutorial/test_options/test_callback/test_tutorial003.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -27,7 +28,7 @@ def test_2():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -37,7 +38,7 @@ def test_script():
 
 def test_completion():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_callback/test_tutorial004.py
+++ b/tests/test_tutorial/test_options/test_callback/test_tutorial004.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -27,7 +28,7 @@ def test_2():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -37,7 +38,7 @@ def test_script():
 
 def test_completion():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_help/test_tutorial001.py
+++ b/tests/test_tutorial/test_options/test_help/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -40,7 +41,7 @@ def test_formal():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_help/test_tutorial002.py
+++ b/tests/test_tutorial/test_options/test_help/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -36,7 +37,7 @@ def test_help():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_help/test_tutorial003.py
+++ b/tests/test_tutorial/test_options/test_help/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -27,7 +28,7 @@ def test_help():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_name/test_tutorial001.py
+++ b/tests/test_tutorial/test_options/test_name/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -27,7 +28,7 @@ def test_call():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_name/test_tutorial002.py
+++ b/tests/test_tutorial/test_options/test_name/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -34,7 +35,7 @@ def test_call_long():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_name/test_tutorial003.py
+++ b/tests/test_tutorial/test_options/test_name/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -28,7 +29,7 @@ def test_call():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_name/test_tutorial004.py
+++ b/tests/test_tutorial/test_options/test_name/test_tutorial004.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -34,7 +35,7 @@ def test_call_long():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_name/test_tutorial005.py
+++ b/tests/test_tutorial/test_options/test_name/test_tutorial005.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -46,7 +47,7 @@ def test_call_condensed_wrong_order():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_prompt/test_tutorial001.py
+++ b/tests/test_tutorial/test_options/test_prompt/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -34,7 +35,7 @@ def test_help():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_prompt/test_tutorial002.py
+++ b/tests/test_tutorial/test_options/test_prompt/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -34,7 +35,7 @@ def test_help():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_prompt/test_tutorial003.py
+++ b/tests/test_tutorial/test_options/test_prompt/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -48,7 +49,7 @@ def test_help():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_required/test_tutorial002.py
+++ b/tests/test_tutorial/test_options/test_required/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 import typer.core
@@ -45,7 +46,7 @@ def test_help_no_rich():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options/test_version/test_tutorial003.py
+++ b/tests/test_tutorial/test_options/test_version/test_tutorial003.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -32,7 +33,7 @@ def test_3():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -42,7 +43,7 @@ def test_script():
 
 def test_completion():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial002.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial002.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -10,7 +11,7 @@ runner = CliRunner()
 
 def test_completion():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -34,7 +35,7 @@ def test_1():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial003.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial003.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -10,7 +11,7 @@ runner = CliRunner()
 
 def test_completion():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -34,7 +35,7 @@ def test_1():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial004.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial004.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -10,7 +11,7 @@ runner = CliRunner()
 
 def test_completion():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -34,7 +35,7 @@ def test_1():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial007.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial007.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -10,7 +11,7 @@ runner = CliRunner()
 
 def test_completion():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -35,7 +36,7 @@ def test_1():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial008.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial008.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -10,7 +11,7 @@ runner = CliRunner()
 
 def test_completion():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -37,7 +38,7 @@ def test_1():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_options_autocompletion/test_tutorial009.py
+++ b/tests/test_tutorial/test_options_autocompletion/test_tutorial009.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -10,7 +11,7 @@ runner = CliRunner()
 
 def test_completion():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, " "],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, " "],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
@@ -37,7 +38,7 @@ def test_1():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -43,7 +44,7 @@ def test_invalid_no_force():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002.py
+++ b/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 import typer.core
@@ -62,7 +63,7 @@ def test_invalid_no_accept():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial003.py
+++ b/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -34,7 +35,7 @@ def test_no_force():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial004.py
+++ b/tests/test_tutorial/test_parameter_types/test_bool/test_tutorial004.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -38,7 +39,7 @@ def test_short_demo():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_datetime/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_datetime/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -43,7 +44,7 @@ def test_invalid():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_datetime/test_tutorial002.py
+++ b/tests/test_tutorial/test_parameter_types/test_datetime/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -25,7 +26,7 @@ def test_usa_weird_date_format():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_enum/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_enum/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -41,7 +42,7 @@ def test_invalid():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_enum/test_tutorial002.py
+++ b/tests/test_tutorial/test_parameter_types/test_enum/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -25,7 +26,7 @@ def test_mix():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_file/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_file/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from pathlib import Path
 
 import typer
@@ -24,7 +25,7 @@ def test_main(tmpdir):
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_file/test_tutorial002.py
+++ b/tests/test_tutorial/test_parameter_types/test_file/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from pathlib import Path
 
 import typer
@@ -26,7 +27,7 @@ def test_main(tmpdir):
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_file/test_tutorial003.py
+++ b/tests/test_tutorial/test_parameter_types/test_file/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from pathlib import Path
 
 import typer
@@ -23,7 +24,7 @@ def test_main(tmpdir):
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_file/test_tutorial004.py
+++ b/tests/test_tutorial/test_parameter_types/test_file/test_tutorial004.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from pathlib import Path
 
 import typer
@@ -27,7 +28,7 @@ def test_main(tmpdir):
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_file/test_tutorial005.py
+++ b/tests/test_tutorial/test_parameter_types/test_file/test_tutorial005.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from pathlib import Path
 
 import typer
@@ -29,7 +30,7 @@ def test_main(tmpdir):
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_index/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_index/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -44,7 +45,7 @@ def test_invalid():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_number/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 import typer.core
@@ -90,7 +91,7 @@ def test_negative_score():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_number/test_tutorial002.py
+++ b/tests/test_tutorial/test_parameter_types/test_number/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -33,7 +34,7 @@ def test_clamped():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_number/test_tutorial003.py
+++ b/tests/test_tutorial/test_parameter_types/test_number/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -49,7 +50,7 @@ def test_verbose_short_3_condensed():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_path/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_path/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from pathlib import Path
 
 import typer
@@ -46,7 +47,7 @@ def test_dir():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_path/test_tutorial002.py
+++ b/tests/test_tutorial/test_parameter_types/test_path/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from pathlib import Path
 
 import typer
@@ -39,7 +40,7 @@ def test_dir():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_parameter_types/test_uuid/test_tutorial001.py
+++ b/tests/test_tutorial/test_parameter_types/test_uuid/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -33,7 +34,7 @@ def test_invalid_uuid():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_prompt/test_tutorial001.py
+++ b/tests/test_tutorial/test_prompt/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -20,7 +21,7 @@ def test_cli():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_prompt/test_tutorial002.py
+++ b/tests/test_tutorial/test_prompt/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -28,7 +29,7 @@ def test_no_confirm():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_prompt/test_tutorial003.py
+++ b/tests/test_tutorial/test_prompt/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -27,7 +28,7 @@ def test_no_confirm():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_callback_override/test_tutorial001.py
+++ b/tests/test_tutorial/test_subcommands/test_callback_override/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -18,7 +19,7 @@ def test_cli():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_callback_override/test_tutorial002.py
+++ b/tests/test_tutorial/test_subcommands/test_callback_override/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -18,7 +19,7 @@ def test_cli():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_callback_override/test_tutorial003.py
+++ b/tests/test_tutorial/test_subcommands/test_callback_override/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -23,7 +24,7 @@ def test_for_coverage():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_callback_override/test_tutorial004.py
+++ b/tests/test_tutorial/test_subcommands/test_callback_override/test_tutorial004.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -25,7 +26,7 @@ def test_for_coverage():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial001.py
+++ b/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_command():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial002.py
+++ b/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_command():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial003.py
+++ b/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_command():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial004.py
+++ b/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial004.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_command():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial005.py
+++ b/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial005.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_command():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial006.py
+++ b/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial006.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_command():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial007.py
+++ b/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial007.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_command():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial008.py
+++ b/tests/test_tutorial/test_subcommands/test_name_help/test_tutorial008.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_command():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_tutorial001.py
+++ b/tests/test_tutorial/test_subcommands/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import pytest
 from typer.testing import CliRunner
@@ -86,7 +87,7 @@ def test_scripts(mod):
 
     for module in [mod, items, users]:
         result = subprocess.run(
-            ["coverage", "run", module.__file__, "--help"],
+            [sys.executable, "-m", "coverage", "run", module.__file__, "--help"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_tutorial002.py
+++ b/tests/test_tutorial/test_subcommands/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -69,7 +70,7 @@ def test_users_delete():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_subcommands/test_tutorial003.py
+++ b/tests/test_tutorial/test_subcommands/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import pytest
 from typer.testing import CliRunner
@@ -159,7 +160,7 @@ def test_scripts(mod):
 
     for module in [mod, items, lands, reigns, towns, users]:
         result = subprocess.run(
-            ["coverage", "run", module.__file__, "--help"],
+            [sys.executable, "-m", "coverage", "run", module.__file__, "--help"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",

--- a/tests/test_tutorial/test_terminating/test_tutorial001.py
+++ b/tests/test_tutorial/test_terminating/test_tutorial001.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -35,7 +36,7 @@ def test_existing_no_standalone():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_terminating/test_tutorial002.py
+++ b/tests/test_tutorial/test_terminating/test_tutorial002.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 from typer.testing import CliRunner
@@ -25,7 +26,7 @@ def test_root():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_terminating/test_tutorial003.py
+++ b/tests/test_tutorial/test_terminating/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import typer
 import typer.core
@@ -44,7 +45,7 @@ def test_root_no_rich():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_testing/test_app01.py
+++ b/tests/test_tutorial/test_testing/test_app01.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from docs_src.testing.app01 import main as mod
 from docs_src.testing.app01.test_main import test_app
@@ -10,7 +11,7 @@ def test_app01():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_testing/test_app02.py
+++ b/tests/test_tutorial/test_testing/test_app02.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from docs_src.testing.app02 import main as mod
 from docs_src.testing.app02.test_main import test_app
@@ -10,7 +11,7 @@ def test_app02():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_testing/test_app03.py
+++ b/tests/test_tutorial/test_testing/test_app03.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from docs_src.testing.app03 import main as mod
 from docs_src.testing.app03.test_main import test_app
@@ -10,7 +11,7 @@ def test_app03():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_using_click/test_tutorial003.py
+++ b/tests/test_tutorial/test_using_click/test_tutorial003.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from click.testing import CliRunner
 
@@ -25,7 +26,7 @@ def test_click():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",

--- a/tests/test_tutorial/test_using_click/test_tutorial004.py
+++ b/tests/test_tutorial/test_using_click/test_tutorial004.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from click.testing import CliRunner
 
@@ -31,7 +32,7 @@ def test_click_dropdb():
 
 def test_script():
     result = subprocess.run(
-        ["coverage", "run", mod.__file__, "--help"],
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",


### PR DESCRIPTION
In some scenarios, like running pytest outside of an active virtualenv,
it could happen that "coverage" would refer to a different Python
interpreter than the one running the tests. Admittedly that does not
happen in standard development scenarios where you use a virtualenv. But
it easily happens when packaging for Linux distributions that support
multiple versions of Python and it can also happen when running pytest
from a virtualenv without activating it. The latter is something that's
convenient when testing versus multiple Python versions without using
tox.

Explicitly invoking coverage as a module on sys.executable ensures that
the same binary, not process, that's also running the tests is used.
This was in fact already done in some tests but not consistently across
all of them.