### PR TITLE
add command_group decorator

### DIFF
--- a/typer/main.py
+++ b/typer/main.py
@@ -257,6 +257,67 @@ class Typer:
 
         return decorator
 
+    def command_group(
+        self,
+        name: Optional[str] = Default(None),
+        *,
+        cls: Optional[Type[TyperGroup]] = Default(None),
+        invoke_without_command: bool = Default(False),
+        no_args_is_help: bool = Default(False),
+        subcommand_metavar: Optional[str] = Default(None),
+        chain: bool = Default(False),
+        result_callback: Optional[Callable[..., Any]] = Default(None),
+        # Command
+        context_settings: Optional[Dict[Any, Any]] = Default(None),
+        callback: Optional[Callable[..., Any]] = Default(None),
+        help: Optional[str] = Default(None),
+        epilog: Optional[str] = Default(None),
+        short_help: Optional[str] = Default(None),
+        options_metavar: str = Default("[OPTIONS]"),
+        add_help_option: bool = Default(True),
+        hidden: bool = Default(False),
+        deprecated: bool = Default(False),
+        add_completion: bool = True,
+        # Rich settings
+        rich_markup_mode: MarkupMode = None,
+        rich_help_panel: Union[str, None] = Default(None),
+        pretty_exceptions_enable: bool = True,
+        pretty_exceptions_show_locals: bool = True,
+        pretty_exceptions_short: bool = True,
+    ) -> Callable[[CommandFunctionType], CommandFunctionType]:
+        if cls is None:
+            cls = TyperCommand
+
+        def decorator(f: CommandFunctionType) -> CommandFunctionType:
+            typer = Typer(
+                name = name or f.__name__,
+                cls = cls,
+                invoke_without_command = invoke_without_command,
+                no_args_is_help = no_args_is_help,
+                subcommand_metavar = subcommand_metavar,
+                chain = chain,
+                result_callback = result_callback,
+                context_settings = context_settings,
+                callback = callback,
+                help = help,
+                epilog = epilog,
+                short_help = short_help,
+                options_metavar = options_metavar,
+                add_help_option = add_help_option,
+                hidden = hidden,
+                deprecated = deprecated,
+                add_completion = add_completion,
+                rich_markup_mode = rich_markup_mode,
+                rich_help_panel = rich_help_panel,
+                pretty_exceptions_enable = pretty_exceptions_enable,
+                pretty_exceptions_show_locals = pretty_exceptions_show_locals,
+                pretty_exceptions_short = pretty_exceptions_short
+            )
+            self.registered_groups.append(TyperInfo(typer))
+            return typer
+
+        return decorator
+    
     def add_typer(
         self,
         typer_instance: "Typer",


### PR DESCRIPTION
Slightly inspired by [Nextcord's subcommand system](https://docs.nextcord.dev/en/stable/interactions.html?highlight=subcommand#subcommands), this decorator could be used to simplify subcommand creation.

My proposed example based on the [reigns and towns example](https://typer.tiangolo.com/tutorial/subcommands/nested-subcommands/#manage-the-land-in-a-cli-app).
```py
import typer

app = typer.Typer()


@app.command_group()
def reigns():
    pass

@reigns.command()
def conquer(name: str):
    print(f"Conquering reign: {name}")

@reigns.command()
def destroy(name: str):
    print(f"Destroying reign: {name}")


@app.command_group()
def towns():
    pass

@towns.command()
def found(name: str):
    print(f"Founding town: {name}")

@towns.command()
def burn(name: str):
    print(f"Burning town: {name}")


if __name__ == "__main__":
    app()
```

Which works exactly like the `lands.py` script from the lined example, except with less code.