### PR TITLE
Support custom parameter types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ Documentation = "https://typer.tiangolo.com/"
 [tool.flit.metadata.requires-extra]
 test = [
     "shellingham >=1.3.0,<2.0.0",
-    "pytest >=4.4.0,<5.4.0",
+    "pytest >=6.2.5",
     "pytest-cov >=2.10.0,<3.0.0",
     "coverage >=5.2,<6.0",
     "pytest-xdist >=1.32.0,<2.0.0",

--- a/tests/test_type_conversion.py
+++ b/tests/test_type_conversion.py
@@ -1,7 +1,8 @@
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
+import click
 import pytest
 import typer
 from typer.testing import CliRunner
@@ -89,4 +90,56 @@ def test_tuple_parameter_elements_are_converted_recursively(type_annotation):
             assert isinstance(element, expected_type)
 
     result = runner.invoke(app, ["one", "two"])
+    assert result.exit_code == 0
+
+
+def test_custom_type():
+    class User:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    app = typer.Typer()
+
+    @app.command()
+    def custom_type(user: User):
+        assert user.name == "John"
+
+    result = runner.invoke(app, ["John"])
+    assert result.exit_code == 0
+
+
+def test_custom_parse():
+    app = typer.Typer()
+
+    @app.command()
+    def custom_parser(
+        hex_value: int = typer.Argument(None, parser=lambda x: int(x, 0))
+    ):
+        assert hex_value == 0x56
+
+    result = runner.invoke(app, ["0x56"])
+    assert result.exit_code == 0
+
+
+def test_custom_click_type():
+    class BaseNumberParamType(click.ParamType):
+        name = "base_integer"
+
+        def convert(
+            self,
+            value: Any,
+            param: Optional[click.Parameter],
+            ctx: Optional[click.Context],
+        ) -> Any:
+            return int(value, 0)
+
+    app = typer.Typer()
+
+    @app.command()
+    def custom_click_type(
+        hex_value: int = typer.Argument(None, click_type=BaseNumberParamType())
+    ):
+        assert hex_value == 0x56
+
+    result = runner.invoke(app, ["0x56"])
     assert result.exit_code == 0

--- a/typer/main.py
+++ b/typer/main.py
@@ -689,7 +689,13 @@ def get_callback(
 def get_click_type(
     *, annotation: Any, parameter_info: ParameterInfo
 ) -> click.ParamType:
-    if annotation == str:
+    if parameter_info.click_type is not None:
+        return parameter_info.click_type
+
+    elif parameter_info.parser is not None:
+        return click.types.FuncParamType(parameter_info.parser)
+
+    elif annotation == str:
         return click.STRING
     elif annotation == int:
         if parameter_info.min is not None or parameter_info.max is not None:
@@ -770,6 +776,9 @@ def get_click_type(
             [item.value for item in annotation],
             case_sensitive=parameter_info.case_sensitive,
         )
+    elif callable(annotation):
+        return click.types.FuncParamType(annotation)
+
     raise RuntimeError(f"Type not yet supported: {annotation}")  # pragma no cover
 
 

--- a/typer/models.py
+++ b/typer/models.py
@@ -184,6 +184,9 @@ class ParameterInfo:
             ]
         ] = None,
         autocompletion: Optional[Callable[..., Any]] = None,
+        # Custom type
+        parser: Optional[Callable[[str], Any]] = None,
+        click_type: Optional[click.ParamType] = None,
         # TyperArgument
         show_default: Union[bool, str] = True,
         show_choices: bool = True,
@@ -225,6 +228,9 @@ class ParameterInfo:
         self.envvar = envvar
         self.shell_complete = shell_complete
         self.autocompletion = autocompletion
+        # Custom type
+        self.parser = parser
+        self.click_type = click_type
         # TyperArgument
         self.show_default = show_default
         self.show_choices = show_choices
@@ -277,6 +283,9 @@ class OptionInfo(ParameterInfo):
             ]
         ] = None,
         autocompletion: Optional[Callable[..., Any]] = None,
+        # Custom type
+        parser: Optional[Callable[[str], Any]] = None,
+        click_type: Optional[click.ParamType] = None,
         # Option
         show_default: bool = True,
         prompt: Union[bool, str] = False,
@@ -327,6 +336,9 @@ class OptionInfo(ParameterInfo):
             envvar=envvar,
             shell_complete=shell_complete,
             autocompletion=autocompletion,
+            # Custom type
+            parser=parser,
+            click_type=click_type,
             # TyperArgument
             show_default=show_default,
             show_choices=show_choices,
@@ -388,6 +400,9 @@ class ArgumentInfo(ParameterInfo):
             ]
         ] = None,
         autocompletion: Optional[Callable[..., Any]] = None,
+        # Custom type
+        parser: Optional[Callable[[str], Any]] = None,
+        click_type: Optional[click.ParamType] = None,
         # TyperArgument
         show_default: Union[bool, str] = True,
         show_choices: bool = True,
@@ -430,6 +445,9 @@ class ArgumentInfo(ParameterInfo):
             envvar=envvar,
             shell_complete=shell_complete,
             autocompletion=autocompletion,
+            # Custom type
+            parser=parser,
+            click_type=click_type,
             # TyperArgument
             show_default=show_default,
             show_choices=show_choices,

--- a/typer/params.py
+++ b/typer/params.py
@@ -24,6 +24,9 @@ def Option(
         ]
     ] = None,
     autocompletion: Optional[Callable[..., Any]] = None,
+    # Custom type
+    parser: Optional[Callable[[str], Any]] = None,
+    click_type: Optional[click.ParamType] = None,
     # Option
     show_default: bool = True,
     prompt: Union[bool, str] = False,
@@ -75,6 +78,9 @@ def Option(
         envvar=envvar,
         shell_complete=shell_complete,
         autocompletion=autocompletion,
+        # Custom type
+        parser=parser,
+        click_type=click_type,
         # Option
         show_default=show_default,
         prompt=prompt,
@@ -133,6 +139,9 @@ def Argument(
         ]
     ] = None,
     autocompletion: Optional[Callable[..., Any]] = None,
+    # Custom type
+    parser: Optional[Callable[[str], Any]] = None,
+    click_type: Optional[click.ParamType] = None,
     # TyperArgument
     show_default: Union[bool, str] = True,
     show_choices: bool = True,
@@ -178,6 +187,9 @@ def Argument(
         envvar=envvar,
         shell_complete=shell_complete,
         autocompletion=autocompletion,
+        # Custom type
+        parser=parser,
+        click_type=click_type,
         # TyperArgument
         show_default=show_default,
         show_choices=show_choices,


### PR DESCRIPTION
While most CLI parameters are strings, ints, etc, we sometimes need custom
types.

Currently typer has no support for it (See #77), and while there are a few hacks, the
likely solution is to add a 'str' argument and parse it inside the main function.

This PR adds support for custom types in 3 different ways:
- Manually specifying a `click_type`
- Manually specifying a `parse` function
- Using a Callable type annotation (It is very common for types to have a string constructor, like `int("1")`)