### PR TITLE
Bump `click` minimum version to 8.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        click-7: [true, false]
       fail-fast: false
 
     steps:
@@ -26,11 +25,8 @@ jobs:
         run: pip install flit
       - name: Install Dependencies
         run: flit install --deps=develop --symlink
-      - name: Install Click 7
-        if: matrix.click-7
-        run: pip install "click<8.0.0"
       - name: Lint
-        if: ${{ matrix.python-version != '3.6' && matrix.click-7 == false }}
+        if: ${{ matrix.python-version != '3.6'}}
         run: bash scripts/lint.sh
       - name: Test
         run: bash scripts/test.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License"
     ]
 requires = [
-    "click >= 7.1.1, <9.0.0"
+    "click >= 8.0.0, <9.0.0"
 ]
 description-file = "README.md"
 requires-python = ">=3.6"


### PR DESCRIPTION
Click major version 7 does not properly work because of the following error: `AttributeError: module 'click.utils' has no attribute '_expand_args'`

The `_expand_args` method was added in click major version 8.

Fixes issue: #427 