### PR TITLE
✏️ Add quotes to package name that includes brackets in docs

### DIFF
--- a/docs/tutorial/package.md
+++ b/docs/tutorial/package.md
@@ -49,7 +49,7 @@ Add `typer[all]` to your dependencies:
 <div class="termy">
 
 ```console
-$ poetry add typer[all]
+$ poetry add "typer[all]"
 
 // It creates a virtual environment for your project
 Creating virtualenv rick-portal-gun-w31dJa0b-py3.6 in /home/rick/.cache/pypoetry/virtualenvs


### PR DESCRIPTION
From poetry's docs: 

>Some shells may treat square braces ([ and ]) as special characters. It is suggested to always quote arguments containing these characters to prevent unexpected shell expansion.
https://python-poetry.org/docs/cli/#add