### PR TITLE
➕ Bring back pytest-cov because coverage can't detect pytest-xdist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Test
         run: bash scripts/test.sh
         env:
-          COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py${{ matrix.python-version }}
-          CONTEXT: ${{ runner.os }}-py${{ matrix.python-version }}
+          COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py${{ matrix.python-version }}-click-7-${{ matrix.click-7 }}
+          CONTEXT: ${{ runner.os }}-py${{ matrix.python-version }}-click-7-${{ matrix.click-7 }}
       - name: Store coverage files
         uses: actions/upload-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,10 @@ Documentation = "https://typer.tiangolo.com/"
 [tool.flit.metadata.requires-extra]
 test = [
     "shellingham >=1.3.0,<2.0.0",
-    "pytest >=4.4.0,<5.4.0",
+    "pytest >=4.4.0,<8.0.0",
     "pytest-cov >=2.10.0,<5.0.0",
     "coverage >=6.2,<7.0",
-    "pytest-xdist >=1.32.0,<2.0.0",
+    "pytest-xdist >=1.32.0,<4.0.0",
     "pytest-sugar >=0.9.4,<0.10.0",
     "mypy ==0.910",
     "black >=22.3.0,<23.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ Documentation = "https://typer.tiangolo.com/"
 test = [
     "shellingham >=1.3.0,<2.0.0",
     "pytest >=4.4.0,<5.4.0",
-    "coverage >=5.2,<7.0",
+    "pytest-cov >=2.10.0,<5.0.0",
+    "coverage >=6.2,<7.0",
     "pytest-xdist >=1.32.0,<2.0.0",
     "pytest-sugar >=0.9.4,<0.10.0",
     "mypy ==0.910",

--- a/scripts/test-cov-html.sh
+++ b/scripts/test-cov-html.sh
@@ -3,7 +3,4 @@
 set -e
 set -x
 
-bash scripts/test.sh ${@}
-coverage combine
-coverage report --show-missing
-coverage html
+bash scripts/test.sh --cov-report=html ${@}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,4 +9,4 @@ export TERMINAL_WIDTH=3000
 export _TYPER_FORCE_DISABLE_TERMINAL=1
 bash ./scripts/test-files.sh
 # Use xdist-pytest --forked to ensure modified sys.path to import relative modules in examples keeps working
-pytest --cov=typer --cov=tests --cov=docs_src --cov-report=term-missing -o console_output_style=progress --forked --numprocesses=auto ${@}
+pytest --cov=typer --cov=tests --cov=docs_src --cov-report=term-missing -o console_output_style=progress --numprocesses=auto ${@}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,4 +9,4 @@ export TERMINAL_WIDTH=3000
 export _TYPER_FORCE_DISABLE_TERMINAL=1
 bash ./scripts/test-files.sh
 # Use xdist-pytest --forked to ensure modified sys.path to import relative modules in examples keeps working
-coverage run -m pytest -o console_output_style=progress --forked --numprocesses=auto ${@}
+pytest --cov=typer --cov=tests --cov=docs_src --cov-report=term-missing -o console_output_style=progress --forked --numprocesses=auto ${@}


### PR DESCRIPTION
➕ Bring back pytest-cov because coverage can't detect pytest-xdist