### PR TITLE
Add typing_extensions dep.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ all = [
     "colorama >=0.4.3,<0.5.0",
     "shellingham >=1.3.0,<2.0.0",
     "rich >=10.11.0,<13.0.0",
-    "typing_extensions >3.6.6; python_version < '3.8'"
+    "typing_extensions >3.6.6; python_version < '3.8'",
 ]
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ all = [
     "colorama >=0.4.3,<0.5.0",
     "shellingham >=1.3.0,<2.0.0",
     "rich >=10.11.0,<13.0.0",
+    "typing_extensions >3.6.6; python_version < '3.8'"
 ]
 
 [tool.isort]


### PR DESCRIPTION
Currently, when running on older versions of python before 3.8, Typer requires the use of typing_extensions for the `Literal` type.

https://github.com/tiangolo/typer/blob/6208b5b2087d3474023cdf650a246c9a6c8327c3/typer/core.py#L30-L33

This was added to that library after typing_extensions 3.6.6 release (diff [here](https://github.com/python/typing_extensions/commit/e538a6ad4666fff7af89d04e95e83a7ecc6507e6)). 

When I run on python3.7 I'm seeing issues when testing my typer clis due to this missing dep.

I'm not the most familiar with the python packaging ecosystem but I pulled the syntax from here:
https://flit.pypa.io/en/stable/pyproject_toml.html#dependencies