### PR TITLE
Fix --help command in Two CLI arguments

### DIFF
--- a/docs/tutorial/first-steps.md
+++ b/docs/tutorial/first-steps.md
@@ -120,11 +120,22 @@ So, extend that to have 2 arguments, `name` and `lastname`:
 // Check the main --help
 $ python main.py --help
 
-<font color="#F4BF75">Usage: </font>main.py [OPTIONS] NAME
-<font color="#A5A5A1">Try </font><font color="#44919F">&apos;main.py </font><font color="#44919F"><b>--help</b></font><font color="#44919F">&apos;</font><font color="#A5A5A1"> for help.</font>
-<font color="#F92672">╭─ Error ───────────────────────────────────────────╮</font>
-<font color="#F92672">│</font> Missing argument &apos;NAME&apos;.                          <font color="#F92672">│</font>
-<font color="#F92672">╰───────────────────────────────────────────────────╯</font>
+<b> </b><font color="#F4BF75"><b>Usage: </b></font><b>main.py [OPTIONS] NAME LASTNAME                            </b>
+<b>                                                                   </b>
+<font color="#A5A5A1">╭─ Arguments ─────────────────────────────────────────────────────╮</font>
+<font color="#A5A5A1">│ </font><font color="#F92672">*</font>    name          <font color="#F4BF75"><b>TEXT</b></font>  [default: None] <font color="#A6194C">[required]</font>             │
+<font color="#A5A5A1">│ </font><font color="#F92672">*</font>    lastname      <font color="#F4BF75"><b>TEXT</b></font>  [default: None] <font color="#A6194C">[required]</font>             │
+<font color="#A5A5A1">╰─────────────────────────────────────────────────────────────────╯</font>
+<font color="#A5A5A1">╭─ Options ───────────────────────────────────────────────────────╮</font>
+<font color="#A5A5A1">│ </font><font color="#A1EFE4"><b>--install-completion</b></font>                     Install completion for │
+<font color="#A5A5A1">│                                          the current shell.     │</font>
+<font color="#A5A5A1">│ </font><font color="#A1EFE4"><b>--show-completion</b></font>                        Show completion for    │
+<font color="#A5A5A1">│                                          the current shell, to  │</font>
+<font color="#A5A5A1">│                                          copy it or customize   │</font>
+<font color="#A5A5A1">│                                          the installation.      │</font>
+<font color="#A5A5A1">│ </font><font color="#A1EFE4"><b>--help</b></font>                                   Show this message and  │
+<font color="#A5A5A1">│                                          exit.                  │</font>
+<font color="#A5A5A1">╰─────────────────────────────────────────────────────────────────╯</font>
 
 <font color="#A1EFE4"><b>typer</b></font> on <font color="#AE81FF"><b> richify</b></font> <font color="#F92672"><b>[»!?] </b></font>via <font color="#F4BF75"><b>🐍 v3.7.5 (env3.7)</b></font>
 <font color="#F92672"><b>❯</b></font> <font color="#A6E22E">python</font> <u style="text-decoration-style:single">main.py</u>


### PR DESCRIPTION
Int his PR, I'm fixing the results in one command in the `First Steps` tutorial. Specifically, in the [Two CLI arguments](https://typer.tiangolo.com/tutorial/first-steps/#two-cli-arguments).

## Problem

In the First Steps tutorial, in [Two CLI arguments](https://typer.tiangolo.com/tutorial/first-steps/#two-cli-arguments) you present a console to explain the results of the `python main.py --help` command. But these results are wrong because, in the original source, the command is failing, but in real life, this is not the case.

![image](https://user-images.githubusercontent.com/18086414/210657420-e8463c35-c4ed-4968-9ee6-caedb40a3ff8.png)

## Local comparison

![image](https://user-images.githubusercontent.com/18086414/210658040-99838a68-2d3f-4763-8e58-56c19c261a6d.png)

## Solution

This is the first time I do a PR for this project and I'm not so good with this code base, so my strategy was to use another section of the documentation to copy, paste and edit to get the right results of the console ([Add one CLI option](https://typer.tiangolo.com/tutorial/first-steps/#add-one-cli-option)).

