### PR TITLE
📝 add no_args_is_help to documentation

### DIFF
--- a/docs/tutorial/arguments/help.md
+++ b/docs/tutorial/arguments/help.md
@@ -318,3 +318,11 @@ If you want to keep Click's convention in a **Typer** app, you can do it with th
 
 !!! note "Technical Details"
     To support `help` in *CLI arguments* **Typer** does a lot of internal work in its own sub-classes of Click's internal classes.
+
+## Show `help` when no arguments are provided
+
+To show the `--help` output when no arguments are provided, set `no_args_is_help` to `True` when creating a `typer.Typer` app
+
+```Python
+typer.Typer(no_args_is_help=True)
+```


### PR DESCRIPTION
PR documents [`no_args_is_help`](https://github.com/tiangolo/typer/blob/master/typer/models.py#L102), since it was hard to discover this option outside of delving into the codebase!