### PR TITLE
handling bytes as strings for param type

### DIFF
--- a/typer/main.py
+++ b/typer/main.py
@@ -697,6 +697,8 @@ def get_click_type(
 
     elif annotation == str:
         return click.STRING
+    elif annotation == bytes:
+        return click.STRING
     elif annotation == int:
         if parameter_info.min is not None or parameter_info.max is not None:
             min_ = None


### PR DESCRIPTION
Because typer is using types from click a BytesParamType() function cannot be added but the click function StringParamType() handles the case of value being bytes so it can handle being passed bytes aswell.