### PR TITLE
👷 Install MkDocs Material Insiders only when secrets are available, for Dependabot

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -58,17 +58,17 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: python -m flit install --extras doc
       - name: Install Material for MkDocs Insiders
-        if: ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false ) && steps.cache.outputs.cache-hit != 'true'
+        if: ( github.event_name != 'pull_request' || github.secret_source == 'Actions' ) && steps.cache.outputs.cache-hit != 'true'
         run: python -m pip install git+https://${{ secrets.TYPER_MKDOCS_MATERIAL_INSIDERS }}@github.com/squidfunk/mkdocs-material-insiders.git
       - uses: actions/cache@v3
         with:
           key: mkdocs-cards-${{ github.ref }}-v1
           path: .cache
       - name: Build Docs
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        if: github.event_name == 'pull_request' && github.secret_source != 'Actions'
         run: python -m mkdocs build
       - name: Build Docs with Insiders
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+        if: github.event_name != 'pull_request' || github.secret_source == 'Actions'
         run: python -m mkdocs build --config-file mkdocs.insiders.yml
 
 


### PR DESCRIPTION
👷 Install MkDocs Material Insiders only when secrets are available, for Dependabot