### PR TITLE
Update optional.md

### DIFF
--- a/docs/tutorial/arguments/optional.md
+++ b/docs/tutorial/arguments/optional.md
@@ -93,7 +93,7 @@ It's still not very useful, but it works correctly.
 And being able to declare a **required** *CLI argument* using
 
 ```Python
-name: Annoated[str, typer.Argument()]
+name: Annotated[str, typer.Argument()]
 ```
 
 ...that works exactly the same as


### PR DESCRIPTION
Fix typo in docu:
`name: Annoated[str, typer.Argument()]`
->
`name: Annotated[str, typer.Argument()]`