### PR TITLE
Update optional.md to fix Typo - Change Annoated to Annotated

### DIFF
--- a/docs/tutorial/arguments/optional.md
+++ b/docs/tutorial/arguments/optional.md
@@ -93,7 +93,7 @@ It's still not very useful, but it works correctly.
 And being able to declare a **required** *CLI argument* using
 
 ```Python
-name: Annoated[str, typer.Argument()]
+name: Annotated[str, typer.Argument()]
 ```
 
 ...that works exactly the same as


### PR DESCRIPTION
There's a typo in the optional.md file for the arguments docs for the word **_Annotated_**. It is named as **_Annoated_**. Fixing the typo to improve the docs.