### PR TITLE
Add StrEnum example for python 3.11+

### DIFF
--- a/docs/tutorial/parameter-types/enum.md
+++ b/docs/tutorial/parameter-types/enum.md
@@ -1,8 +1,18 @@
 To define a *CLI parameter* that can take a value from a predefined set of values you can use a standard Python <a href="https://docs.python.org/3/library/enum.html" class="external-link" target="_blank">`enum.Enum`</a>:
 
-```Python hl_lines="1  6 7 8 9  12 13"
-{!../docs_src/parameter_types/enum/tutorial001.py!}
-```
+
+=== "Python 3.11+"
+
+    ```Python hl_lines="1  6 7 8 9  12 13"
+    {!> ../docs_src/parameter_types/enum/tutorial001_v3_11.py!}
+    ```
+
+=== "Python 3.6+"
+
+    ```Python hl_lines="1  6 7 8 9  12 13"
+    {!> ../docs_src/parameter_types/enum/tutorial001.py!}
+    ```
+
 
 !!! tip
     Notice that the function parameter `network` will be an `Enum`, not a `str`.
@@ -42,6 +52,12 @@ Error: Invalid value for '--network': invalid choice: capsule. (choose from simp
 ### Case insensitive Enum choices
 
 You can make an `Enum` (choice) *CLI parameter* be case-insensitive with the `case_sensitive` parameter:
+
+=== "Python 3.11+"
+
+    ```Python hl_lines="15"
+    {!> ../docs_src/parameter_types/enum/tutorial002_an_v3_11.py!}
+    ```
 
 === "Python 3.6+"
 

--- a/docs_src/parameter_types/enum/tutorial001_v3_11.py
+++ b/docs_src/parameter_types/enum/tutorial001_v3_11.py
@@ -1,0 +1,17 @@
+from enum import StrEnum
+
+import typer
+
+
+class NeuralNetwork(StrEnum):
+    simple = "simple"
+    conv = "conv"
+    lstm = "lstm"
+
+
+def main(network: NeuralNetwork = NeuralNetwork.simple):
+    print(f"Training neural network of type: {network.value}")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/docs_src/parameter_types/enum/tutorial002_an_v3_11.py
+++ b/docs_src/parameter_types/enum/tutorial002_an_v3_11.py
@@ -1,0 +1,22 @@
+from enum import StrEnum
+
+import typer
+from typing_extensions import Annotated
+
+
+class NeuralNetwork(StrEnum):
+    simple = "simple"
+    conv = "conv"
+    lstm = "lstm"
+
+
+def main(
+    network: Annotated[
+        NeuralNetwork, typer.Option(case_sensitive=False)
+    ] = NeuralNetwork.simple
+):
+    print(f"Training neural network of type: {network.value}")
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
Python 3.11 added StrEnum, that can replace using `MyEnum(str, Enum)`.

This adds that usage to the Enum parameter type docs, while also keeping the old usage for users on older versions of Python.