### PR TITLE
💡 Add comments to document overload definitions in code

### DIFF
--- a/typer/params.py
+++ b/typer/params.py
@@ -251,6 +251,7 @@ def Option(
     )
 
 
+# Overload for Argument created with custom type 'parser'
 @overload
 def Argument(
     # Parameter
@@ -305,6 +306,7 @@ def Argument(
     ...
 
 
+# Overload for Argument created with custom type 'click_type'
 @overload
 def Argument(
     # Parameter

--- a/typer/params.py
+++ b/typer/params.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:  # pragma: no cover
     import click.shell_completion
 
 
+# Overload for Option created with custom type 'parser'
 @overload
 def Option(
     # Parameter
@@ -71,6 +72,7 @@ def Option(
     ...
 
 
+# Overload for Option created with custom type 'click_type'
 @overload
 def Option(
     # Parameter


### PR DESCRIPTION
Merely a comment in code to help developers understand the difference between the different `overload` definitions (as it took me some time to figure out)