### PR TITLE
📝 Update docs example for a Typer/Click group to make new subcommands explicit

### DIFF
--- a/docs/tutorial/using-click.md
+++ b/docs/tutorial/using-click.md
@@ -94,12 +94,19 @@ Check it:
 <div class="termy">
 
 ```console
-$ python main.py
+$ python main.py --help
 
 // Notice we have both subcommands, top and hello
 Usage: main.py [OPTIONS] COMMAND [ARGS]...
 
-Error: Missing command.
+Options:
+  --install-completion  Install completion for the current shell.
+  --show-completion     Show completion for the current shell, to copy it or customize the installation.
+  --help                Show this message and exit.
+
+Commands:
+  hello
+  top
 
 // Call the Typer part
 $ python main.py top

--- a/tests/test_tutorial/test_using_click/test_tutorial003.py
+++ b/tests/test_tutorial/test_using_click/test_tutorial003.py
@@ -14,6 +14,14 @@ def test_cli():
     assert "Missing command" in result.stdout or "Usage" in result.stdout
 
 
+def test_help():
+    result = runner.invoke(mod.typer_click_object, ["--help"])
+    assert result.exit_code == 0
+    assert "Commands" in result.output
+    assert "top" in result.output
+    assert "hello" in result.output
+
+
 def test_typer():
     result = runner.invoke(mod.typer_click_object, ["top"])
     assert "The Typer app is at the top level" in result.stdout


### PR DESCRIPTION
In the [documentation](https://typer.tiangolo.com/tutorial/using-click/#including-a-click-app-in-a-typer-app), an example is given of a Typer app that includes a Click app. The example reads

> // Notice we have both subcommands, top and hello

But for the user to actually see this, they should call `main.py` with `--help` specifically. I've updated the docs accordingly, and added a unit test to ensure that both commands are indeed shown in the help function.