### PR TITLE
🔧 Refactor package manager, move from Flit to PDM, remove private pip extras for `test`, `doc`, `dev`

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -17,9 +17,9 @@ jobs:
     outputs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-    - uses: actions/checkout@v3
-    # For pull requests it's not necessary to checkout the code but for the main branch it is
-    - uses: dorny/paths-filter@v2
+    - uses: actions/checkout@v4
+    # For pull requests it's not necessary to checkout the code but for master it is
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         filters: |
@@ -27,6 +27,7 @@ jobs:
             - README.md
             - docs/**
             - docs_src/**
+            - requirements-docs.txt
             - pyproject.toml
             - mkdocs.yml
             - mkdocs.insiders.yml
@@ -43,25 +44,25 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - uses: actions/cache@v3
         id: cache
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-python-docs-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-v01
-      - name: Install Flit
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: python -m pip install flit
+          key: ${{ runner.os }}-python-docs-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'requirements-docs.txt') }}-v01
       - name: Install docs extras
         if: steps.cache.outputs.cache-hit != 'true'
-        run: python -m flit install --extras doc
+        run: pip install -r requirements-docs.txt
       - name: Install Material for MkDocs Insiders
-        if: ( github.event_name != 'pull_request' || github.secret_source == 'Actions' ) && steps.cache.outputs.cache-hit != 'true'
-        run: python -m pip install git+https://${{ secrets.TYPER_MKDOCS_MATERIAL_INSIDERS }}@github.com/squidfunk/mkdocs-material-insiders.git
+        if: ( github.event_name != 'pull_request' || github.secret_source != 'Actions' ) && steps.cache.outputs.cache-hit != 'true'
+        run: |
+          pip install git+https://${{ secrets.TYPER_MKDOCS_MATERIAL_INSIDERS }}@github.com/squidfunk/mkdocs-material-insiders.git
+          pip install git+https://${{ secrets.TYPER_MKDOCS_MATERIAL_INSIDERS }}@github.com/pawamoy-insiders/griffe-typing-deprecated.git
+          pip install git+https://${{ secrets.TYPER_MKDOCS_MATERIAL_INSIDERS }}@github.com/pawamoy-insiders/mkdocstrings-python.git
       - uses: actions/cache@v3
         with:
           key: mkdocs-cards-${{ github.ref }}-v1
@@ -70,9 +71,8 @@ jobs:
         if: github.event_name == 'pull_request' && github.secret_source != 'Actions'
         run: python -m mkdocs build
       - name: Build Docs with Insiders
-        if: github.event_name != 'pull_request' || github.secret_source == 'Actions'
+        if: ( github.event_name != 'pull_request' || github.secret_source != 'Actions' )
         run: python -m mkdocs build --config-file mkdocs.insiders.yml
-
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,14 +14,14 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Clean site
         run: |
           rm -rf ./site
           mkdir ./site
       - name: Download Artifact Docs
         id: download
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@v3.1.4
         with:
           if_no_artifact_found: ignore
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,17 +9,33 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.7"
-      - name: Install Flit
-        run: pip install flit
-      - name: Install Dependencies
-        run: flit install --symlink
-      - name: Publish
+      - name: Dump GitHub context
         env:
-          FLIT_USERNAME: ${{ secrets.FLIT_USERNAME }}
-          FLIT_PASSWORD: ${{ secrets.FLIT_PASSWORD }}
-        run: bash scripts/publish.sh
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          # Issue ref: https://github.com/actions/setup-python/issues/436
+          # cache: "pip"
+          # cache-dependency-path: pyproject.toml
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
+      - name: Install build dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pip install build
+      - name: Build distribution
+        run: python -m build
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.8.11
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,26 +5,38 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize]
+    types:
+      - opened
+      - synchronize
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
-
     steps:
-      - uses: actions/checkout@v3
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Flit
-        run: pip install flit
+          # Issue ref: https://github.com/actions/setup-python/issues/436
+          # cache: "pip"
+          # cache-dependency-path: pyproject.toml
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'requirements-tests.txt') }}
       - name: Install Dependencies
-        run: python -m flit install --symlink
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pip install -r requirements-tests.txt
       - name: Lint
         run: bash scripts/lint.sh
       - run: mkdir coverage
@@ -42,27 +54,28 @@ jobs:
   coverage-combine:
     needs: [test]
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v4
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
-
+          # Issue ref: https://github.com/actions/setup-python/issues/436
+          # cache: "pip"
+          # cache-dependency-path: pyproject.toml
       - name: Get coverage files
         uses: actions/download-artifact@v3
         with:
           name: coverage
           path: coverage
-
       - run: pip install coverage[toml]
-
       - run: ls -la coverage
       - run: coverage combine coverage
       - run: coverage report
       - run: coverage html --show-contexts --title "Coverage for ${{ github.sha }}"
-
       - name: Store coverage HTML
         uses: actions/upload-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,16 @@
 [build-system]
-requires = ["flit_core >=2,<3"]
-build-backend = "flit_core.buildapi"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
-[tool.flit.metadata]
-module = "typer"
-author = "Sebastián Ramírez"
-author-email = "tiangolo@gmail.com"
-home-page = "https://github.com/tiangolo/typer"
+[project]
+name = "typer"
+dynamic = ["version"]
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+authors = [
+    {name = "Sebastián Ramírez", email = "tiangolo@gmail.com"},
+]
+readme = "README.md"
+requires-python = ">=3.7"
 classifiers = [
     "Intended Audience :: Information Technology",
     "Intended Audience :: System Administrators",
@@ -26,48 +30,26 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "License :: OSI Approved :: MIT License"
-    ]
-requires = [
+    "License :: OSI Approved :: MIT License",
+]
+dependencies = [
     "click >= 8.0.0",
     "typing-extensions >= 3.7.4.3",
 ]
-description-file = "README.md"
-requires-python = ">=3.7"
 
-[tool.flit.metadata.urls]
+[project.urls]
 Documentation = "https://typer.tiangolo.com/"
+homepage = "https://github.com/tiangolo/typer"
 
-[tool.flit.metadata.requires-extra]
-test = [
-    "shellingham >=1.3.0,<2.0.0",
-    "pytest >=4.4.0,<8.0.0",
-    "pytest-cov >=2.10.0,<5.0.0",
-    "coverage >=6.2,<7.0",
-    "pytest-xdist >=1.32.0,<4.0.0",
-    "pytest-sugar >=0.9.4,<0.10.0",
-    "mypy ==0.971",
-    "black >=22.3.0,<23.0.0",
-    "isort >=5.0.6,<6.0.0",
-    "rich >=10.11.0,<14.0.0",
-]
-doc = [
-    "mkdocs >=1.1.2,<2.0.0",
-    "mkdocs-material >=8.1.4,<9.0.0",
-    "mdx-include >=1.4.1,<2.0.0",
-    "pillow >=9.3.0,<10.0.0",
-    "cairosvg >=2.5.2,<3.0.0",
-]
-dev = [
-    "autoflake >=1.3.1,<2.0.0",
-    "flake8 >=3.8.3,<4.0.0",
-    "pre-commit >=2.17.0,<3.0.0",
-]
+[project.optional-dependencies]
 all = [
     "colorama >=0.4.3,<0.5.0",
     "shellingham >=1.3.0,<2.0.0",
     "rich >=10.11.0,<14.0.0",
 ]
+
+[tool.pdm]
+version = { source = "file", path = "typer/__init__.py" }
 
 [tool.isort]
 profile = "black"
@@ -89,7 +71,6 @@ filterwarnings = [
     "error",
     # TODO: until I refactor completion to use the new shell_complete
     "ignore:'autocompletion' is renamed to 'shell_complete'. The old name is deprecated and will be removed in Click 8.1. See the docs about 'Parameter' for information about new behavior.:DeprecationWarning:typer",
-    'ignore:starlette.middleware.wsgi is deprecated and will be removed in a future release\..*:DeprecationWarning:starlette',
     # For pytest-xdist
     'ignore::DeprecationWarning:xdist',
 ]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,17 @@
+-e .
+
+mkdocs-material==9.4.7
+mdx-include >=1.4.1,<2.0.0
+mkdocs-markdownextradata-plugin >=0.1.7,<0.3.0
+mkdocs-redirects>=1.2.1,<1.3.0
+pyyaml >=5.3.1,<7.0.0
+# For Material for MkDocs, Chinese search
+jieba==0.42.1
+# For image processing by Material for MkDocs
+pillow==10.1.0
+# For image processing by Material for MkDocs
+cairosvg==2.7.0
+mkdocstrings[python]==0.23.0
+griffe-typingdoc==0.2.2
+# For griffe, it formats with black
+black==23.3.0

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,7 +2,7 @@
 
 pytest >=4.4.0,<8.0.0
 pytest-cov >=2.10.0,<5.0.0
-coverage >=6.2,<7.0
+coverage[toml] >=6.2,<7.0
 pytest-xdist >=1.32.0,<4.0.0
 pytest-sugar >=0.9.4,<0.10.0
 mypy ==0.971

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,10 @@
+-e .[all]
+
+pytest >=4.4.0,<8.0.0
+pytest-cov >=2.10.0,<5.0.0
+coverage >=6.2,<7.0
+pytest-xdist >=1.32.0,<4.0.0
+pytest-sugar >=0.9.4,<0.10.0
+mypy ==0.971
+black >=22.3.0,<23.0.0
+isort >=5.0.6,<6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+-e .[all]
+
+-r requirements-tests.txt
+-r requirements-docs.txt
+
+pre-commit >=2.17.0,<4.0.0


### PR DESCRIPTION
🔧 Refactor package manager, move from Flit to PDM, remove private pip extras for `test`, `doc`, `dev`