### PR TITLE
📝 Update console output with Click 8 messages

### DIFF
--- a/docs/tutorial/commands/callback.md
+++ b/docs/tutorial/commands/callback.md
@@ -67,7 +67,7 @@ $ python main.py create --verbose Camila
 Usage: main.py create [OPTIONS] USERNAME
 Try "main.py create --help" for help.
 
-Error: no such option: --verbose
+Error: No such option: --verbose
 ```
 
 </div>

--- a/docs/tutorial/commands/options.md
+++ b/docs/tutorial/commands/options.md
@@ -67,13 +67,13 @@ Creating user: Camila
 // Now test the command delete
 $ python main.py delete Camila
 
-# Are you sure you want to delete the user? [y/N]: $ y
+# Are you sure you want to delete the user? [y/n]: $ y
 
 Deleting user: Camila
 
 $ python main.py delete Wade
 
-# Are you sure you want to delete the user? [y/N]: $ n
+# Are you sure you want to delete the user? [y/n]: $ n
 
 Operation cancelled
 
@@ -82,13 +82,13 @@ Operation cancelled
 
 $ python main.py delete-all
 
-# Are you sure you want to delete ALL users? [y/N]: $ y
+# Are you sure you want to delete ALL users? [y/n]: $ y
 
 Deleting all users
 
 $ python main.py delete-all
 
-# Are you sure you want to delete ALL users? [y/N]: $ n
+# Are you sure you want to delete ALL users? [y/n]: $ n
 
 Operation cancelled
 

--- a/docs/tutorial/multiple-values/arguments-with-multiple-values.md
+++ b/docs/tutorial/multiple-values/arguments-with-multiple-values.md
@@ -72,7 +72,7 @@ Hello Ron
 // If you pass an invalid number of arguments you will get an error
 $ python main.py Draco Hagrid
 
-Error: argument names takes 3 values
+Error: Argument 'names' takes 3 values
 
 // And if you pass the exact number of values it will work correctly
 $ python main.py Draco Hagrid Dobby

--- a/docs/tutorial/multiple-values/options-with-multiple-values.md
+++ b/docs/tutorial/multiple-values/options-with-multiple-values.md
@@ -95,7 +95,7 @@ The username Morty has 3 coins
 // Try with invalid values (not enough)
 $ python main.py --user Camila 50
 
-Error: --user option requires 3 arguments
+Error: Option '--user' requires 3 arguments
 ```
 
 </div>

--- a/docs/tutorial/options/prompt.md
+++ b/docs/tutorial/options/prompt.md
@@ -108,7 +108,7 @@ $ python main.py
 # Project name: $ Old Project
 # Repeat for confirmation: $ New Spice
 
-Error: the two entered values do not match
+Error: The two entered values do not match
 
 # Project name: $ Old Project
 # Repeat for confirmation: $ Old Project

--- a/docs/tutorial/parameter-types/bool.md
+++ b/docs/tutorial/parameter-types/bool.md
@@ -54,7 +54,7 @@ $ python main.py --no-force
 Usage: main.py [OPTIONS]
 Try "main.py --help" for help.
 
-Error: no such option: --no-force
+Error: No such option: --no-force
 ```
 
 </div>

--- a/docs/tutorial/parameter-types/datetime.md
+++ b/docs/tutorial/parameter-types/datetime.md
@@ -38,7 +38,7 @@ $ python main.py july-19-1989
 
 Usage: main.py [OPTIONS] [%Y-%m-%d|%Y-%m-%dT%H:%M:%S|%Y-%m-%d%H:%M:%S]
 
-Error: Invalid value for '[%Y-%m-%d|%Y-%m-%dT%H:%M:%S|%Y-%m-%d %H:%M:%S]': invalid datetime format: july-19-1989. (choose from %Y-%m-%d, %Y-%m-%dT%H:%M:%S, %Y-%m-%d %H:%M:%S)
+Error: Invalid value for 'BIRTH:[%Y-%m-%d|%Y-%m-%dT%H:%M:%S|%Y-%m-%d %H:%M:%S]': 'july-19-1989' does not match the formats '%Y-%m-%d', '%Y-%m-%dT%H:%M:%S', '%Y-%m-%d %H:%M:%S'.
 ```
 
 </div>

--- a/docs/tutorial/parameter-types/enum.md
+++ b/docs/tutorial/parameter-types/enum.md
@@ -34,7 +34,7 @@ $ python main.py --network capsule
 Usage: main.py [OPTIONS]
 Try "main.py --help" for help.
 
-Error: Invalid value for '--network': invalid choice: capsule. (choose from simple, conv, lstm)
+Error: Invalid value for '--network': 'capsule' is not one of 'simple', 'conv', 'lstm'.
 
 // Note that enums are case sensitive by default
 $ python main.py --network CONV
@@ -42,7 +42,7 @@ $ python main.py --network CONV
 Usage: main.py [OPTIONS]
 Try "main.py --help" for help.
 
-Error: Invalid value for '--network': invalid choice: CONV. (choose from simple, conv, lstm)
+Error: Invalid value for '--network': 'CONV' is not one of 'simple', 'conv', 'lstm'.
 ```
 
 </div>

--- a/docs/tutorial/parameter-types/index.md
+++ b/docs/tutorial/parameter-types/index.md
@@ -50,7 +50,7 @@ $ python main.py Camila --age 15.3
 Usage: main.py [OPTIONS] NAME
 Try "main.py --help" for help.
 
-Error: Invalid value for '--age': 15.3 is not a valid integer
+Error: Invalid value for '--age': '15.3' is not a valid integer
 
 // Because 15.3 is not an INTEGER (it's a float)
 ```

--- a/docs/tutorial/parameter-types/number.md
+++ b/docs/tutorial/parameter-types/number.md
@@ -50,7 +50,7 @@ $ python main.py 1002
 Usage: main.py [OPTIONS] ID
 Try "main.py --help" for help.
 
-Error: Invalid value for 'ID': 1002 is not in the valid range of 0 to 1000.
+Error: Invalid value for 'ID': 1002 is not in the range 0<=x<=1000.
 
 // Pass an invalid age
 $ python main.py 5 --age 15
@@ -58,7 +58,7 @@ $ python main.py 5 --age 15
 Usage: main.py [OPTIONS] ID
 Try "main.py --help" for help.
 
-Error: Invalid value for '--age': 15 is smaller than the minimum valid value 18.
+Error: Invalid value for '--age': 15 is not in the range x>=18.
 
 // Pass an invalid score
 $ python main.py 5 --age 20 --score 100.5
@@ -66,7 +66,7 @@ $ python main.py 5 --age 20 --score 100.5
 Usage: main.py [OPTIONS] ID
 Try "main.py --help" for help.
 
-Error: Invalid value for '--score': 100.5 is bigger than the maximum valid value 100.
+Error: Invalid value for '--score': 100.5 is not in the range x<=100.
 
 // But as we didn't specify a minimum score, this is accepted
 $ python main.py 5 --age 20 --score -5
@@ -110,7 +110,7 @@ $ python main.py 1002
 Usage: main.py [OPTIONS] ID
 Try "main.py --help" for help.
 
-Error: Invalid value for 'ID': 1002 is not in the valid range of 0 to 1000.
+Error: Invalid value for 'ID': 1002 is not in the range 0<=x<=1000.
 
 // But --rank and --score use clamp
 $ python main.py 5 --rank 11 --score -5

--- a/docs/tutorial/parameter-types/uuid.md
+++ b/docs/tutorial/parameter-types/uuid.md
@@ -42,7 +42,7 @@ $ python main.py 7479706572-72756c6573
 Usage: main.py [OPTIONS] USER_ID
 Try "main.py --help" for help.
 
-Error: Invalid value for 'USER_ID': 7479706572-72756c6573 is not a valid UUID value
+Error: Invalid value for 'USER_ID': 7479706572-72756c6573 is not a valid UUID.
 ```
 
 </div>


### PR DESCRIPTION
PR https://github.com/tiangolo/typer/pull/760 removed Click 7 support, and accordingly removed the Click 7 console messages from the unit tests (e.g. see [here](https://github.com/tiangolo/typer/commit/5bea9cf205df92cb24526f63ac6c6dc9d2b888c2#diff-780b1cd026f4279bd0ec0358daee6b9320bc503c68b0b0a099f27a2bd313b5f5)). This PR updates all the log messages in the documentation to the Click 8 variants as well.