### PR TITLE
🐛 Fix Rich formatting with no commands

### DIFF
--- a/tests/test_rich_utils.py
+++ b/tests/test_rich_utils.py
@@ -39,7 +39,7 @@ def test_rich_utils_click_rewrapp():
 
 
 def test_rich_help_no_commands():
-    """Ensure that the help still works for a Typer instance wit no commands, but with a callback."""
+    """Ensure that the help still works for a Typer instance with no commands, but with a callback."""
     app = typer.Typer(help="My cool Typer app")
 
     @app.callback(invoke_without_command=True, no_args_is_help=True)

--- a/tests/test_rich_utils.py
+++ b/tests/test_rich_utils.py
@@ -36,3 +36,17 @@ def test_rich_utils_click_rewrapp():
     assert "Hello World" in result.stdout
     result = runner.invoke(app, ["secondary"])
     assert "Hello Secondary World" in result.stdout
+
+
+def test_rich_help_no_commands():
+    """Ensure that the help still works for a Typer instance wit no commands, but with a callback."""
+    app = typer.Typer(help="My cool Typer app")
+
+    @app.callback(invoke_without_command=True, no_args_is_help=True)
+    def main() -> None:
+        return None
+
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Show this message" in result.stdout

--- a/tests/test_rich_utils.py
+++ b/tests/test_rich_utils.py
@@ -44,7 +44,7 @@ def test_rich_help_no_commands():
 
     @app.callback(invoke_without_command=True, no_args_is_help=True)
     def main() -> None:
-        return None
+        return None  # pragma: no cover
 
     result = runner.invoke(app, ["--help"])
 

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -644,7 +644,8 @@ def rich_format_help(
                 len(command.name or "")
                 for commands in panel_to_commands.values()
                 for command in commands
-            ], default=0
+            ],
+            default=0,
         )
 
         # Print each command group panel

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -644,7 +644,7 @@ def rich_format_help(
                 len(command.name or "")
                 for commands in panel_to_commands.values()
                 for command in commands
-            ]
+            ], default=0
         )
 
         # Print each command group panel


### PR DESCRIPTION
When taking the `max` of the list of commands, define a `default` value to guard against calling `max` on an empty list, which would raise an error. (this is also how I had it in the original [suggestion](https://github.com/tiangolo/typer/pull/567#discussion_r1553956210))

Fixes https://github.com/PrefectHQ/prefect/issues/12617
Fixes https://github.com/tiangolo/typer/discussions/795