### PR TITLE
✅ Generalize test suite to run on Windows

### DIFF
--- a/tests/test_completion/test_completion.py
+++ b/tests/test_completion/test_completion.py
@@ -29,7 +29,7 @@ def test_install_completion():
         [
             "bash",
             "-c",
-            f"{sys.executable} -m coverage run {mod.__file__} --install-completion",
+            f"'{sys.executable}' -m coverage run '{mod.__file__}' --install-completion",
         ],
         capture_output=True,
         encoding="utf-8",
@@ -38,7 +38,7 @@ def test_install_completion():
     new_text = bash_completion_path.read_text()
     bash_completion_path.write_text(text)
     assert "source" in new_text
-    assert ".bash_completions/tutorial001.py.sh" in new_text
+    assert str(Path(".bash_completions/tutorial001.py.sh")) in new_text
     assert "completion installed in" in result.stdout
     assert "Completion will take effect once you restart the terminal" in result.stdout
 

--- a/tests/test_completion/test_completion.py
+++ b/tests/test_completion/test_completion.py
@@ -11,7 +11,7 @@ def test_show_completion():
         [
             "bash",
             "-c",
-            f"{sys.executable}  -m coverage run {mod.__file__} --show-completion",
+            f"'{sys.executable}' -m coverage run '{mod.__file__}' --show-completion",
         ],
         capture_output=True,
         encoding="utf-8",

--- a/tests/test_completion/test_completion_install.py
+++ b/tests/test_completion/test_completion_install.py
@@ -52,9 +52,9 @@ def test_completion_install_bash():
     )
     new_text = bash_completion_path.read_text()
     bash_completion_path.write_text(text)
-    install_source = ".bash_completions/tutorial001.py.sh"
-    assert install_source not in text
-    assert install_source in new_text
+    install_source = Path(".bash_completions/tutorial001.py.sh")
+    assert str(install_source) not in text
+    assert str(install_source) in new_text
     assert "completion installed in" in result.stdout
     assert "Completion will take effect once you restart the terminal" in result.stdout
     install_source_path = Path.home() / install_source


### PR DESCRIPTION
Ensure that the test suite runs properly on Windows by:
- adding quotes when paths can have spaces or backslashes
- using `Pathlib` to automatically parse the correct path separator, rather than relying on the literal string `"/"`

Related PR: https://github.com/tiangolo/typer/pull/809