### PR TITLE
Adds anchors to commands lists in generated docs

### DIFF
--- a/tests/assets/cli/multiapp-docs-title.md
+++ b/tests/assets/cli/multiapp-docs-title.md
@@ -18,8 +18,8 @@ The end
 
 **Commands**:
 
-* `sub`
-* `top`: Top command
+* [`sub`](#multiapp-sub)
+* [`top`](#multiapp-top): Top command
 
 ## `multiapp sub`
 
@@ -35,9 +35,9 @@ $ multiapp sub [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `bye`: Say bye
-* `hello`: Say Hello
-* `hi`: Say Hi
+* [`bye`](#multiapp-sub-bye): Say bye
+* [`hello`](#multiapp-sub-hello): Say Hello
+* [`hi`](#multiapp-sub-hi): Say Hi
 
 ### `multiapp sub bye`
 

--- a/tests/assets/cli/multiapp-docs.md
+++ b/tests/assets/cli/multiapp-docs.md
@@ -18,8 +18,8 @@ The end
 
 **Commands**:
 
-* `sub`
-* `top`: Top command
+* [`sub`](#multiapp-sub)
+* [`top`](#multiapp-top): Top command
 
 ## `multiapp sub`
 
@@ -35,9 +35,9 @@ $ multiapp sub [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `bye`: Say bye
-* `hello`: Say Hello
-* `hi`: Say Hi
+* [`bye`](#multiapp-sub-bye): Say bye
+* [`hello`](#multiapp-sub-hello): Say Hello
+* [`hi`](#multiapp-sub-hi): Say Hi
 
 ### `multiapp sub bye`
 

--- a/typer/cli.py
+++ b/typer/cli.py
@@ -244,7 +244,8 @@ def get_docs_for_click(
             for command in commands:
                 command_obj = group.get_command(ctx, command)
                 assert command_obj
-                docs += f"* `{command_obj.name}`"
+                command_anchor = f"{command_name.lower().replace(' ', '-')}-{command_obj.name.lower().replace(' ', '-')}"
+                docs += f"* [`{command_obj.name}`](#{command_anchor})"
                 command_help = command_obj.get_short_help_str()
                 if command_help:
                     docs += f": {command_help}"


### PR DESCRIPTION
This PR adds markdown anchors to commands lists in [generated documentation](https://typer.tiangolo.com/tutorial/typer-command/#generate-docs-with-the-typer-command) to improve navigation.