### PR TITLE
Fix use of options_metavar

### DIFF
--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -256,3 +256,21 @@ def test_split_opt():
     prefix, opt = _split_opt("verbose")
     assert prefix == ""
     assert opt == "verbose"
+
+
+def test_options_metadata_typer_default():
+    app = typer.Typer(options_metavar="[options]")
+
+    @app.command()
+    def c1():
+        pass  # pragma: nocover
+
+    @app.command(options_metavar="[OPTS]")
+    def c2():
+        pass  # pragma: nocover
+
+    result = runner.invoke(app, ["c1", "--help"])
+    assert "Usage: root c1 [options]" in result.stdout
+
+    result = runner.invoke(app, ["c2", "--help"])
+    assert "Usage: root c2 [OPTS]" in result.stdout

--- a/typer/main.py
+++ b/typer/main.py
@@ -181,7 +181,7 @@ class Typer:
         help: Optional[str] = Default(None),
         epilog: Optional[str] = Default(None),
         short_help: Optional[str] = Default(None),
-        options_metavar: str = Default("[OPTIONS]"),
+        options_metavar: Optional[str] = None,
         add_help_option: bool = Default(True),
         hidden: bool = Default(False),
         deprecated: bool = Default(False),
@@ -202,7 +202,7 @@ class Typer:
                 help=help,
                 epilog=epilog,
                 short_help=short_help,
-                options_metavar=options_metavar,
+                options_metavar=options_metavar or self.info.options_metavar,
                 add_help_option=add_help_option,
                 hidden=hidden,
                 deprecated=deprecated,
@@ -221,7 +221,7 @@ class Typer:
         help: Optional[str] = None,
         epilog: Optional[str] = None,
         short_help: Optional[str] = None,
-        options_metavar: str = "[OPTIONS]",
+        options_metavar: Optional[str] = None,
         add_help_option: bool = True,
         no_args_is_help: bool = False,
         hidden: bool = False,
@@ -242,7 +242,9 @@ class Typer:
                     help=help,
                     epilog=epilog,
                     short_help=short_help,
-                    options_metavar=options_metavar,
+                    options_metavar=(
+                        options_metavar or self._info_val_str("options_metavar")
+                    ),
                     add_help_option=add_help_option,
                     no_args_is_help=no_args_is_help,
                     hidden=hidden,
@@ -272,7 +274,7 @@ class Typer:
         help: Optional[str] = Default(None),
         epilog: Optional[str] = Default(None),
         short_help: Optional[str] = Default(None),
-        options_metavar: str = Default("[OPTIONS]"),
+        options_metavar: Optional[str] = None,
         add_help_option: bool = Default(True),
         hidden: bool = Default(False),
         deprecated: bool = Default(False),
@@ -294,7 +296,7 @@ class Typer:
                 help=help,
                 epilog=epilog,
                 short_help=short_help,
-                options_metavar=options_metavar,
+                options_metavar=options_metavar or self.info.options_metavar,
                 add_help_option=add_help_option,
                 hidden=hidden,
                 deprecated=deprecated,
@@ -324,6 +326,12 @@ class Typer:
                 ),
             )
             raise e
+
+    def _info_val_str(self, name: str) -> str:
+        val = getattr(self.info, name)
+        val_str = val.value if isinstance(val, DefaultPlaceholder) else val
+        assert isinstance(val_str, str)
+        return val_str
 
 
 def get_group(typer_instance: Typer) -> TyperGroup:


### PR DESCRIPTION
Typer was ignoring this setting when provided to commands. Refer to added test for details.