### PR TITLE
✅ Add CI configs to run tests on Windows and MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        python_version: [ "3.11" ]
+        include:
+          - os: ubuntu-latest
+            python_version: "3.7"
+          - os: macos-latest
+            python_version: "3.8"
+          - os: windows-latest
+            python_version: "3.9"
+          - os: ubuntu-latest
+            python_version: "3.10"
       fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Dump GitHub context
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python_version: [ "3.11" ]
+        python-version: [ "3.11" ]
         include:
           - os: ubuntu-latest
             python_version: "3.7"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ matrix.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'requirements-tests.txt') }}
+          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'requirements-tests.txt') }}
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r requirements-tests.txt
@@ -57,12 +57,12 @@ jobs:
       - name: Test
         run: bash scripts/test.sh
         env:
-          COVERAGE_FILE: coverage/.coverage.${{ matrix.os }}-py${{ matrix.python-version }}
-          CONTEXT: ${{ matrix.os }}-py${{ matrix.python-version }}
+          COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py${{ matrix.python-version }}
+          CONTEXT: ${{ runner.os }}-py${{ matrix.python-version }}
       - name: Store coverage files
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
+          name: coverage-${{ runner.os }}-${{ matrix.python-version }}
           path: coverage
 
   coverage-combine:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Store coverage files
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.python-version }}
+          name: coverage-${{ matrix.python-version }}-${{ matrix.os }}
           path: coverage
 
   coverage-combine:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'requirements-tests.txt') }}
+          key: ${{ matrix.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'requirements-tests.txt') }}
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r requirements-tests.txt
@@ -57,12 +57,12 @@ jobs:
       - name: Test
         run: bash scripts/test.sh
         env:
-          COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py${{ matrix.python-version }}
-          CONTEXT: ${{ runner.os }}-py${{ matrix.python-version }}
+          COVERAGE_FILE: coverage/.coverage.${{ matrix.os }}-py${{ matrix.python-version }}
+          CONTEXT: ${{ matrix.os }}-py${{ matrix.python-version }}
       - name: Store coverage files
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.python-version }}-${{ matrix.os }}
+          name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
           path: coverage
 
   coverage-combine:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
         python-version: [ "3.11" ]
         include:
           - os: ubuntu-latest
-            python_version: "3.7"
+            python-version: "3.7"
           - os: macos-latest
-            python_version: "3.8"
+            python-version: "3.8"
           - os: windows-latest
-            python_version: "3.9"
+            python-version: "3.9"
           - os: ubuntu-latest
-            python_version: "3.10"
+            python-version: "3.10"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
           # cache: "pip"
           # cache-dependency-path: pyproject.toml
       - uses: actions/cache@v3
+        if: ${{ runner.os != 'macOS' }}
         id: cache
         with:
           path: ${{ env.pythonLocation }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,13 +117,6 @@ filterwarnings = [
     'ignore::DeprecationWarning:xdist',
 ]
 
-[tool.coverage.paths]
-source = [
-    "docs_src",
-    "tests",
-    "typer"
-]
-
 [tool.coverage.run]
 parallel = true
 data_file = "coverage/.coverage"
@@ -136,6 +129,7 @@ omit = [
     "typer/_typing.py"
 ]
 context = '${CONTEXT}'
+relative_files = true
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,13 @@ filterwarnings = [
     'ignore::DeprecationWarning:xdist',
 ]
 
+[tool.coverage.paths]
+source = [
+    "docs_src",
+    "tests",
+    "typer"
+]
+
 [tool.coverage.run]
 parallel = true
 data_file = "coverage/.coverage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ exclude_lines = [
     'if __name__ == "__main__":',
     "if TYPE_CHECKING:",
 ]
+ignore_errors = true
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,6 @@ exclude_lines = [
     'if __name__ == "__main__":',
     "if TYPE_CHECKING:",
 ]
-ignore_errors = true
 
 [tool.mypy]
 strict = true

--- a/tests/test_completion/test_completion.py
+++ b/tests/test_completion/test_completion.py
@@ -3,14 +3,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
 from docs_src.commands.index import tutorial001 as mod
+from tests.utils import needs_linux
 
 
-@pytest.mark.skipif(
-    not sys.platform.startswith("linux"), reason="Test designed for Linux/bash"
-)
+@needs_linux
 def test_show_completion():
     result = subprocess.run(
         [
@@ -25,9 +22,7 @@ def test_show_completion():
     assert "_TUTORIAL001.PY_COMPLETE=complete_bash" in result.stdout
 
 
-@pytest.mark.skipif(
-    not sys.platform.startswith("linux"), reason="Test designed for Linux/bash"
-)
+@needs_linux
 def test_install_completion():
     bash_completion_path: Path = Path.home() / ".bashrc"
     text = ""

--- a/tests/test_completion/test_completion.py
+++ b/tests/test_completion/test_completion.py
@@ -4,10 +4,13 @@ import sys
 from pathlib import Path
 
 import pytest
+
 from docs_src.commands.index import tutorial001 as mod
 
 
-@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Test designed for Linux/bash")
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="Test designed for Linux/bash"
+)
 def test_show_completion():
     result = subprocess.run(
         [
@@ -22,7 +25,9 @@ def test_show_completion():
     assert "_TUTORIAL001.PY_COMPLETE=complete_bash" in result.stdout
 
 
-@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Test designed for Linux/bash")
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="Test designed for Linux/bash"
+)
 def test_install_completion():
     bash_completion_path: Path = Path.home() / ".bashrc"
     text = ""

--- a/tests/test_completion/test_completion.py
+++ b/tests/test_completion/test_completion.py
@@ -3,9 +3,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 from docs_src.commands.index import tutorial001 as mod
 
 
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Test designed for Linux/bash")
 def test_show_completion():
     result = subprocess.run(
         [
@@ -20,6 +22,7 @@ def test_show_completion():
     assert "_TUTORIAL001.PY_COMPLETE=complete_bash" in result.stdout
 
 
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Test designed for Linux/bash")
 def test_install_completion():
     bash_completion_path: Path = Path.home() / ".bashrc"
     text = ""

--- a/tests/test_completion/test_completion.py
+++ b/tests/test_completion/test_completion.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 from docs_src.commands.index import tutorial001 as mod
+
 from ..utils import needs_linux
 
 

--- a/tests/test_completion/test_completion.py
+++ b/tests/test_completion/test_completion.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 from docs_src.commands.index import tutorial001 as mod
-from tests.utils import needs_linux
+from ..utils import needs_linux
 
 
 @needs_linux

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial004.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial004.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -55,5 +56,6 @@ def test_script():
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         capture_output=True,
         encoding="utf-8",
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
     )
     assert "Usage" in result.stdout

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial004_an.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial004_an.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -55,5 +56,6 @@ def test_script():
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         capture_output=True,
         encoding="utf-8",
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
     )
     assert "Usage" in result.stdout

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial005.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial005.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -56,5 +57,6 @@ def test_script():
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         capture_output=True,
         encoding="utf-8",
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
     )
     assert "Usage" in result.stdout

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial005_an.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial005_an.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -56,5 +57,6 @@ def test_script():
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         capture_output=True,
         encoding="utf-8",
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
     )
     assert "Usage" in result.stdout

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial006.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial006.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -47,5 +48,6 @@ def test_script():
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         capture_output=True,
         encoding="utf-8",
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
     )
     assert "Usage" in result.stdout

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial007.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial007.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import os
 
 from typer.testing import CliRunner
 
@@ -8,6 +9,8 @@ from docs_src.commands.help import tutorial007 as mod
 app = mod.app
 
 runner = CliRunner()
+
+ENV = {**os.environ, "PYTHONIOENCODING": "utf-8"}
 
 
 def test_main_help():
@@ -51,5 +54,6 @@ def test_script():
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         capture_output=True,
         encoding="utf-8",
+        env=ENV,
     )
     assert "Usage" in result.stdout

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial007.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial007.py
@@ -1,6 +1,6 @@
+import os
 import subprocess
 import sys
-import os
 
 from typer.testing import CliRunner
 

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial007.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial007.py
@@ -10,8 +10,6 @@ app = mod.app
 
 runner = CliRunner()
 
-ENV = {**os.environ, "PYTHONIOENCODING": "utf-8"}
-
 
 def test_main_help():
     result = runner.invoke(app, ["--help"])
@@ -54,6 +52,6 @@ def test_script():
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         capture_output=True,
         encoding="utf-8",
-        env=ENV,
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
     )
     assert "Usage" in result.stdout

--- a/tests/test_tutorial/test_commands/test_help/test_tutorial007_an.py
+++ b/tests/test_tutorial/test_commands/test_help/test_tutorial007_an.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -51,5 +52,6 @@ def test_script():
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         capture_output=True,
         encoding="utf-8",
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
     )
     assert "Usage" in result.stdout

--- a/tests/test_tutorial/test_parameter_types/test_file/test_tutorial004.py
+++ b/tests/test_tutorial/test_parameter_types/test_file/test_tutorial004.py
@@ -18,7 +18,7 @@ def test_main(tmpdir):
     if binary_file.exists():  # pragma: no cover
         binary_file.unlink()
     result = runner.invoke(app, ["--file", f"{binary_file}"])
-    text = binary_file.read_text()
+    text = binary_file.read_text(encoding="utf-8")
     binary_file.unlink()
     assert result.exit_code == 0
     assert "Binary file written" in result.output

--- a/tests/test_tutorial/test_parameter_types/test_file/test_tutorial004_an.py
+++ b/tests/test_tutorial/test_parameter_types/test_file/test_tutorial004_an.py
@@ -18,7 +18,7 @@ def test_main(tmpdir):
     if binary_file.exists():  # pragma: no cover
         binary_file.unlink()
     result = runner.invoke(app, ["--file", f"{binary_file}"])
-    text = binary_file.read_text()
+    text = binary_file.read_text(encoding="utf-8")
     binary_file.unlink()
     assert result.exit_code == 0
     assert "Binary file written" in result.output

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,3 +5,7 @@ import pytest
 needs_py310 = pytest.mark.skipif(
     sys.version_info < (3, 10), reason="requires python3.10+"
 )
+
+needs_linux = pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="Test requires Linux"
+)

--- a/typer/_completion_shared.py
+++ b/typer/_completion_shared.py
@@ -106,7 +106,7 @@ def install_bash(*, prog_name: str, complete_var: str, shell: str) -> Path:
     rc_content = ""
     if rc_path.is_file():
         rc_content = rc_path.read_text()
-    completion_init_lines = [f"source '{completion_path}'"]
+    completion_init_lines = [f"source {completion_path}"]
     for line in completion_init_lines:
         if line not in rc_content:  # pragma: no cover
             rc_content += f"\n{line}"

--- a/typer/_completion_shared.py
+++ b/typer/_completion_shared.py
@@ -106,7 +106,7 @@ def install_bash(*, prog_name: str, complete_var: str, shell: str) -> Path:
     rc_content = ""
     if rc_path.is_file():
         rc_content = rc_path.read_text()
-    completion_init_lines = [f"source {completion_path}"]
+    completion_init_lines = [f"source '{completion_path}'"]
     for line in completion_init_lines:
         if line not in rc_content:  # pragma: no cover
             rc_content += f"\n{line}"


### PR DESCRIPTION
Extend test suite:
- Testing on a matrix of different Python and OS versions
- Not running all possible combinations as that seems overkill
- Run the latest Python version (3.11 here) on all three OS's
- Not yet including Python 3.12 - I can update https://github.com/tiangolo/typer/pull/807 separately after merging this.

In total, this runs the CI two more times than before (7 instead of 5). 

## Fixes 

To get the CI to go green for all systems, following edits/fixes were required:

### Ensure we're always reading in UTF-8

`tests/test_tutorial/test_parameter_types/test_file/test_tutorial004(_an)` failed on Windows:
```
AssertionError: assert 'la cig�e�a trae al ni�o' in 'some settings\nla cigüeña trae al niño'
```

To fix it, I set the `encoding` for `read_text` to be `utf8`.

### Skip completion tests for Windows and MacOS

This isn't the cleanest of solutions, but it seems to me that these completion tests were very much written to work on Linux/bash only. In the future, it'd be nice to have MacOS & Windows compatible tests for this - I can make an issue for it to follow up later?

### Use OS in coverage report name
By including the OS in the  `coverage` file, we prevent overwriting / confusion:

![image](https://github.com/tiangolo/typer/assets/8796347/ceb00c1b-d88b-4289-97d8-2bb77b1f5cbc)


### Windows encoding issue with `coverage run`

Added an `env` argument to `subprocess.run` calls that were failing for the `test_commands/test_help` `test_script` tests. I'm still not clear why we were getting `UnicodeDecodeError`'s for these. I double checked all files in the `typer` codebase and couldn't find any with a wrong decoding. Something must be happening when calling `coverage run`. Either way, by taking inspiration from [ cpython#105312](https://github.com/python/cpython/issues/105312#issuecomment-1919348455) and [chaiNNer#2815](https://github.com/chaiNNer-org/chaiNNer/pull/2815) it seems to be fixed.

### MacOS issue with Python dir caching

The Python installation is being cached with `actions/cache@v3`, which refers to `env.pythonLocation`. However on macOS, this directory appears to be empty. The "Post Run" log would mention 
> Cache Size: ~0MB (478 B)

and then the next run would appear to "successfully" restore from this cache, but the commands wouldn't actually be available:

![image](https://github.com/tiangolo/typer/assets/8796347/8d45a0d6-3a75-4876-90af-b6677e0af869)

Cf also a related discussion https://github.com/actions/setup-python/issues/813. I decided to implement the same workaround as https://github.com/microsoft/torchgeo/pull/2024, basically disabling the caching for MacOS.

### Windows issue with Python dir caching

One remaining issue is to investigate why the Windows caching isn't currently working:

![image](https://github.com/tiangolo/typer/assets/8796347/716b2553-db47-48ec-a299-45f05a945dc6)

This is not necessary to get this PR green, so I suggest to keep this as follow-up work.

### Fix combining coverage files from different OS's

When combining the different `.coverage.XXX` files from the different runs in the matrix, `coverage` needs to [remap](https://coverage.readthedocs.io/en/latest/cmd.html#re-mapping-paths) the locations. It's easier to just use the [`relative_files`](https://coverage.readthedocs.io/en/latest/config.html#config-run-relative-files) option as suggested in the Coverage docs.
