### PR TITLE
Fix typer command cannot run scripts that imports other scripts

### DIFF
--- a/tests/assets/cli/import_other.py
+++ b/tests/assets/cli/import_other.py
@@ -1,5 +1,7 @@
 from imported_by_other import hello
+from subdir.imported_nested import echo
 
 
 def main(name: str):
     hello(name)
+    echo(name)

--- a/tests/assets/cli/import_other.py
+++ b/tests/assets/cli/import_other.py
@@ -1,0 +1,5 @@
+from imported_by_other import hello
+
+
+def main(name: str):
+    hello(name)

--- a/tests/assets/cli/imported_by_other.py
+++ b/tests/assets/cli/imported_by_other.py
@@ -1,0 +1,2 @@
+def hello(name):
+    print(f"Hello {name}")

--- a/tests/assets/cli/subdir/imported_nested.py
+++ b/tests/assets/cli/subdir/imported_nested.py
@@ -1,0 +1,2 @@
+def echo(arg):
+    print(f"echo: {arg}")

--- a/tests/test_cli/test_import_other.py
+++ b/tests/test_cli/test_import_other.py
@@ -19,3 +19,4 @@ def test_script():
         encoding="utf-8",
     )
     assert "Hello Dr. Magic" in result.stdout
+    assert "echo: Dr. Magic" in result.stdout

--- a/tests/test_cli/test_import_other.py
+++ b/tests/test_cli/test_import_other.py
@@ -1,0 +1,21 @@
+import subprocess
+import sys
+
+
+def test_script():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            "-m",
+            "typer",
+            "tests/assets/cli/import_other.py",
+            "run",
+            "Dr. Magic"
+        ],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert "Hello Dr. Magic" in result.stdout

--- a/typer/cli.py
+++ b/typer/cli.py
@@ -122,6 +122,8 @@ def get_typer_from_state() -> Optional[typer.Typer]:
     if state.file:
         module_name = state.file.name
         spec = importlib.util.spec_from_file_location(module_name, str(state.file))
+        # the module may import other modules in the same directory
+        sys.path.append(str(state.file.parent))
     elif state.module:
         spec = importlib.util.find_spec(state.module)
     if spec is None:


### PR DESCRIPTION
## Issue

`typer` command cannot run a script which imports other scripts in the same directory, or in the subdirectory. 

The original problem comes from https://github.com/tiangolo/typer-cli/discussions/142, and I still can reproduce this with typer version 0.12.3.

## Changes I Made

- add `sys.path.append(str(state.file.parent))` before `exec_module`
- add a test for this

You can check that the test won't pass without the modification of `sys.path`.
