### PR TITLE
:sparkles: Remove Rich tags when showing completion text

### DIFF
--- a/typer/completion.py
+++ b/typer/completion.py
@@ -15,6 +15,12 @@ try:
 except ImportError:  # pragma: no cover
     shellingham = None
 
+try:
+    import rich
+
+except ImportError:  # pragma: no cover
+    rich = None  # type: ignore
+
 
 _click_patched = False
 
@@ -141,9 +147,17 @@ def shell_complete(
         click.echo(comp.source())
         return 0
 
+    # Typer override to print the completion help msg with Rich
     if instruction == "complete":
-        click.echo(comp.complete())
+        if rich is None:
+            click.echo(comp.complete())
+        else:
+            from . import rich_utils
+
+            rich_utils.print_with_rich(comp.complete())
+
         return 0
+    # Typer override end
 
     click.echo(f'Completion instruction "{instruction}" not supported.', err=True)
     return 1

--- a/typer/rich_utils.py
+++ b/typer/rich_utils.py
@@ -709,3 +709,9 @@ def rich_abort_error() -> None:
     """Print richly formatted abort error."""
     console = _get_rich_console(stderr=True)
     console.print(ABORTED_TEXT, style=STYLE_ABORTED)
+
+
+def print_with_rich(text: str) -> None:
+    """Print richly formatted message."""
+    console = _get_rich_console()
+    console.print(text)


### PR DESCRIPTION
Upon completion, print the help text with Rich if it's available. Fixes #822.

Original behaviour, as reported in #822: hitting TAB TAB shows the autocompletion with literal Rich formatting, e.g. 
> goodbye  -- Say [bold]goodbye[/bold] to the user.

With this PR, the Rich tags are removed:
> goodbye  -- Say goodbye to the user.

In my experiments, this does remove the Rich tags from the output, though it does not yet actually format the text with the right colors etc. Not sure whether that's due to the shells/OS's I've tried - further input from others using different systems would be appreciated!

## Powershell on Windows

- [x] Shows Rich tags in completion text with `master`
- [x] Removes Rich tags in completion text with this PR
- [x] Shell is able to show Rich formatting in simple script
- [ ] Shows Rich formatting in completion text with this PR


## GitBash using `zsh` shell on Windows

I couldn't yet get this shell to work with Rich formatting - probably because it's an emulated shell.

- [x] Shows Rich tags in completion text with `master`
- [x] Removes Rich tags in completion text with this PR
- [ ] Shell is able to show Rich formatting in simple script
- [ ] Shows Rich formatting in completion text with this PR
