### PR TITLE
🔧 Update MkDocs to have titles in Markdown files instead of config

### DIFF
--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -1,3 +1,5 @@
+# Alternatives, Inspiration and Comparisons
+
 What inspired **Typer**, how it compares to other alternatives and what it learned from them.
 
 ## Intro

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,5 @@
+# Development - Contributing
+
 First, you might want to see the basic ways to [help Typer and get help](help-typer.md){.internal-link target=_blank}.
 
 ## Developing

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,3 +1,5 @@
+# Features
+
 ## Design based on **FastAPI**
 
 <a href="https://fastapi.tiangolo.com" target="_blank"><img src="https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png" style="width: 20%;"></a>

--- a/docs/help-typer.md
+++ b/docs/help-typer.md
@@ -1,3 +1,5 @@
+# Help Typer - Get Help
+
 Are you liking **Typer**?
 
 Would you like to help Typer, other users, and the author?

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,5 @@
+# Release Notes
+
 ## Latest Changes
 
 ### Features

--- a/docs/tutorial/app-dir.md
+++ b/docs/tutorial/app-dir.md
@@ -1,3 +1,5 @@
+# CLI Application Directory
+
 You can get the application directory where you can, for example, save configuration files with `typer.get_app_dir()`:
 
 ```Python hl_lines="9"

--- a/docs/tutorial/arguments/default.md
+++ b/docs/tutorial/arguments/default.md
@@ -1,3 +1,5 @@
+# CLI Arguments with Default
+
 We can also use the same `typer.Argument()` to set a default value.
 
 That way the *CLI argument* will be optional *and also* have a default value.

--- a/docs/tutorial/arguments/envvar.md
+++ b/docs/tutorial/arguments/envvar.md
@@ -1,3 +1,5 @@
+# CLI Arguments with Environment Variables
+
 You can also configure a *CLI argument* to read a value from an environment variable if it is not provided in the command line as a *CLI argument*.
 
 To do that, use the `envvar` parameter for `typer.Argument()`:

--- a/docs/tutorial/arguments/help.md
+++ b/docs/tutorial/arguments/help.md
@@ -1,3 +1,5 @@
+# CLI Arguments with Help
+
 In the *First Steps* section you saw how to add help for a CLI app/command by adding it to a function's <abbr title="a multi-line string as the first expression inside a function (not assigned to any variable) used for documentation">docstring</abbr>.
 
 Here's how that last example looked like:

--- a/docs/tutorial/arguments/index.md
+++ b/docs/tutorial/arguments/index.md
@@ -1,3 +1,5 @@
+# CLI Arguments
+
 In the next few sections we'll see some ways to modify how *CLI arguments* work.
 
 We'll create optional *CLI arguments*, we'll add integrated help for *CLI arguments*, etc.

--- a/docs/tutorial/arguments/optional.md
+++ b/docs/tutorial/arguments/optional.md
@@ -1,3 +1,5 @@
+# Optional CLI Arguments
+
 We said before that *by default*:
 
 * *CLI options* are **optional**

--- a/docs/tutorial/arguments/other-uses.md
+++ b/docs/tutorial/arguments/other-uses.md
@@ -1,3 +1,5 @@
+# Other uses
+
 `typer.Argument()` has several other use cases. Such as for data validation, to enable other features, etc.
 
 You will see about these use cases later in the docs.

--- a/docs/tutorial/commands/arguments.md
+++ b/docs/tutorial/commands/arguments.md
@@ -1,3 +1,5 @@
+# Command CLI Arguments
+
 The same way as with a CLI application with a single command, subcommands (or just "commands") can also have their own *CLI arguments*:
 
 ```Python hl_lines="7  12"

--- a/docs/tutorial/commands/callback.md
+++ b/docs/tutorial/commands/callback.md
@@ -1,3 +1,5 @@
+# Typer Callback
+
 When you create an `app = typer.Typer()` it works as a group of commands.
 
 And you can create multiple commands with it.

--- a/docs/tutorial/commands/context.md
+++ b/docs/tutorial/commands/context.md
@@ -1,3 +1,5 @@
+# Using the Context
+
 When you create a **Typer** application it uses Click underneath. And every Click application has a special object called a <a href="https://click.palletsprojects.com/en/8.1.x/commands/#nested-handling-and-contexts" class="external-link" target="_blank">"Context"</a> that is normally hidden.
 
 But you can access the context by declaring a function parameter of type `typer.Context`.

--- a/docs/tutorial/commands/help.md
+++ b/docs/tutorial/commands/help.md
@@ -1,3 +1,5 @@
+# Command Help
+
 The same as before, you can add help for the commands in the docstrings and the *CLI options*.
 
 And the `typer.Typer()` application receives a parameter `help` that you can pass with the main help text for your CLI program:

--- a/docs/tutorial/commands/index.md
+++ b/docs/tutorial/commands/index.md
@@ -1,3 +1,5 @@
+# Commands
+
 We have seen how to create a CLI program with possibly several *CLI options* and *CLI arguments*.
 
 But **Typer** allows you to create CLI programs with several commands (also known as subcommands).

--- a/docs/tutorial/commands/name.md
+++ b/docs/tutorial/commands/name.md
@@ -1,3 +1,5 @@
+# Custom Command Name
+
 By default, the command names are generated from the function name.
 
 So, if your function is something like:

--- a/docs/tutorial/commands/one-or-multiple.md
+++ b/docs/tutorial/commands/one-or-multiple.md
@@ -1,3 +1,5 @@
+# One or Multiple Commands
+
 You might have noticed that if you create a single command, as in the first example:
 
 ```Python hl_lines="3  6  12"

--- a/docs/tutorial/commands/options.md
+++ b/docs/tutorial/commands/options.md
@@ -1,3 +1,5 @@
+# Command CLI Options
+
 Commands can also have their own *CLI options*.
 
 In fact, each command can have different *CLI arguments* and *CLI options*:

--- a/docs/tutorial/first-steps.md
+++ b/docs/tutorial/first-steps.md
@@ -1,3 +1,5 @@
+# First Steps
+
 ## The simplest example
 
 The simplest **Typer** file could look like this:

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,3 +1,5 @@
+# Tutorial - User Guide
+
 ## Python types
 
 If you need a refresher about how to use Python type hints, check the first part of <a href="https://fastapi.tiangolo.com/python-types/" class="external-link" target="_blank">FastAPI's Python types intro</a>.

--- a/docs/tutorial/launch.md
+++ b/docs/tutorial/launch.md
@@ -1,3 +1,5 @@
+# Launching Applications
+
 You can launch applications from your CLI program with `typer.launch()`.
 
 It will launch the appropriate application depending on the URL or file type you pass it:

--- a/docs/tutorial/multiple-values/arguments-with-multiple-values.md
+++ b/docs/tutorial/multiple-values/arguments-with-multiple-values.md
@@ -1,3 +1,5 @@
+# CLI Arguments with Multiple Values
+
 *CLI arguments* can also receive multiple values.
 
 You can define the type of a *CLI argument* using `typing.List`.

--- a/docs/tutorial/multiple-values/index.md
+++ b/docs/tutorial/multiple-values/index.md
@@ -1,3 +1,5 @@
+# Multiple Values
+
 There are several ways to declare multiple values for *CLI options* and *CLI arguments*.
 
 We'll see them in the next short sections.

--- a/docs/tutorial/multiple-values/multiple-options.md
+++ b/docs/tutorial/multiple-values/multiple-options.md
@@ -1,3 +1,5 @@
+# Multiple CLI Options
+
 You can declare a *CLI option* that can be used multiple times, and then get all the values.
 
 For example, let's say you want to accept several users in a single execution.

--- a/docs/tutorial/multiple-values/options-with-multiple-values.md
+++ b/docs/tutorial/multiple-values/options-with-multiple-values.md
@@ -1,3 +1,5 @@
+# CLI Options with Multiple Values
+
 You can also declare a *CLI option* that takes several values of different types.
 
 You can set the number of values and types to anything you want, but it has to be a fixed number of values.

--- a/docs/tutorial/options-autocompletion.md
+++ b/docs/tutorial/options-autocompletion.md
@@ -1,3 +1,5 @@
+# CLI Option autocompletion
+
 As you have seen, apps built with **Typer** have completion in your shell that works when you create a Python package or using the `typer` command.
 
 It normally completes *CLI options*, *CLI arguments*, and subcommands (that you will learn about later).

--- a/docs/tutorial/options/callback-and-context.md
+++ b/docs/tutorial/options/callback-and-context.md
@@ -1,3 +1,5 @@
+# CLI Option Callback and Context
+
 In some occasions you might want to have some custom logic for a specific *CLI parameter* (for a *CLI option*  or *CLI argument*) that is executed with the value received from the terminal.
 
 In those cases you can use a *CLI parameter* callback function.

--- a/docs/tutorial/options/help.md
+++ b/docs/tutorial/options/help.md
@@ -1,3 +1,5 @@
+# CLI Options with Help
+
 You already saw how to add a help text for *CLI arguments* with the `help` parameter.
 
 Let's now do the same for *CLI options*:

--- a/docs/tutorial/options/index.md
+++ b/docs/tutorial/options/index.md
@@ -1,3 +1,5 @@
+# CLI Options
+
 In the next short sections we will see how to modify *CLI options* using `typer.Option()`.
 
 `typer.Option()` works very similarly to `typer.Argument()`, but has some extra features that we'll see next.

--- a/docs/tutorial/options/name.md
+++ b/docs/tutorial/options/name.md
@@ -1,3 +1,5 @@
+# CLI Option Name
+
 By default **Typer** will create a *CLI option* name from the function parameter.
 
 So, if you have a function with:

--- a/docs/tutorial/options/password.md
+++ b/docs/tutorial/options/password.md
@@ -1,3 +1,5 @@
+# Password CLI Option and Confirmation Prompt
+
 Apart from having a prompt, you can make a *CLI option* have a `confirmation_prompt=True`:
 
 //// tab | Python 3.7+

--- a/docs/tutorial/options/prompt.md
+++ b/docs/tutorial/options/prompt.md
@@ -1,3 +1,5 @@
+# CLI Option Prompt
+
 It's also possible to, instead of just showing an error, ask for the missing value with `prompt=True`:
 
 //// tab | Python 3.7+

--- a/docs/tutorial/options/required.md
+++ b/docs/tutorial/options/required.md
@@ -1,3 +1,5 @@
+# Required CLI Options
+
 We said before that *by default*:
 
 * *CLI options* are **optional**

--- a/docs/tutorial/options/version.md
+++ b/docs/tutorial/options/version.md
@@ -1,3 +1,5 @@
+# Version CLI Option, `is_eager`
+
 You could use a callback to implement a `--version` *CLI option*.
 
 It would show the version of your CLI program and then it would terminate it. Even before any other *CLI parameter* is processed.

--- a/docs/tutorial/package.md
+++ b/docs/tutorial/package.md
@@ -1,3 +1,5 @@
+# Building a Package
+
 When you create a CLI program with **Typer** you probably want to create your own Python package.
 
 That's what allows your users to install it and have it as an independent program that they can use in their terminal.

--- a/docs/tutorial/parameter-types/bool.md
+++ b/docs/tutorial/parameter-types/bool.md
@@ -1,3 +1,5 @@
+# Boolean CLI Options
+
 We have seen some examples of *CLI options* with `bool`, and how **Typer** creates `--something` and `--no-something` automatically.
 
 But we can customize those names.

--- a/docs/tutorial/parameter-types/custom-types.md
+++ b/docs/tutorial/parameter-types/custom-types.md
@@ -1,3 +1,5 @@
+# Custom Types
+
 You can easily use your own custom types in your **Typer** applications.
 
 The way to do it is by providing a way to <abbr title="convert from some plain format, like the input text in the CLI, into Python objects">parse</abbr> input into your own types.

--- a/docs/tutorial/parameter-types/datetime.md
+++ b/docs/tutorial/parameter-types/datetime.md
@@ -1,3 +1,5 @@
+# DateTime
+
 You can specify a *CLI parameter* as a Python <a href="https://docs.python.org/3/library/datetime.html" class="external-link" target="_blank">`datetime`</a>.
 
 Your function will receive a standard Python `datetime` object, and again, your editor will give you completion, etc.

--- a/docs/tutorial/parameter-types/enum.md
+++ b/docs/tutorial/parameter-types/enum.md
@@ -1,3 +1,5 @@
+# Enum - Choices
+
 To define a *CLI parameter* that can take a value from a predefined set of values you can use a standard Python <a href="https://docs.python.org/3/library/enum.html" class="external-link" target="_blank">`enum.Enum`</a>:
 
 ```Python hl_lines="1  6 7 8 9  12 13"

--- a/docs/tutorial/parameter-types/file.md
+++ b/docs/tutorial/parameter-types/file.md
@@ -1,3 +1,5 @@
+# File
+
 Apart from `Path` *CLI parameters* you can also declare some types of "files".
 
 /// tip

--- a/docs/tutorial/parameter-types/index.md
+++ b/docs/tutorial/parameter-types/index.md
@@ -1,3 +1,5 @@
+# CLI Parameter Types
+
 You can use several data types for the *CLI options* and *CLI arguments*, and you can add data validation requirements too.
 
 ## Data conversion

--- a/docs/tutorial/parameter-types/number.md
+++ b/docs/tutorial/parameter-types/number.md
@@ -1,3 +1,5 @@
+# Number
+
 You can define numeric validations with `max` and `min` values for `int` and `float` *CLI parameters*:
 
 //// tab | Python 3.7+

--- a/docs/tutorial/parameter-types/path.md
+++ b/docs/tutorial/parameter-types/path.md
@@ -1,3 +1,5 @@
+# Path
+
 You can declare a *CLI parameter* to be a standard Python <a href="https://docs.python.org/3/library/pathlib.html#basic-use" class="external-link" target="_blank">`pathlib.Path`</a>.
 
 This is what you would do for directory paths, file paths, etc:

--- a/docs/tutorial/parameter-types/uuid.md
+++ b/docs/tutorial/parameter-types/uuid.md
@@ -1,3 +1,5 @@
+# UUID
+
 /// info
 
 A UUID is a <a href="https://en.wikipedia.org/wiki/Universally_unique_identifier" class="external-link" target="_blank">"Universally Unique Identifier"</a>.

--- a/docs/tutorial/printing.md
+++ b/docs/tutorial/printing.md
@@ -1,3 +1,5 @@
+# Printing and Colors
+
 You can use the normal `print()` to show information on the screen:
 
 ```Python hl_lines="5"

--- a/docs/tutorial/progressbar.md
+++ b/docs/tutorial/progressbar.md
@@ -1,3 +1,5 @@
+# Progress Bar
+
 If you are executing an operation that can take some time, you can inform it to the user. 🤓
 
 ## Progress Bar

--- a/docs/tutorial/prompt.md
+++ b/docs/tutorial/prompt.md
@@ -1,3 +1,5 @@
+# Ask with Prompt
+
 When you need to ask the user for info interactively you should normally use [*CLI Option*s with Prompt](options/prompt.md){.internal-link target=_blank}, because they allow using the CLI program in a non-interactive way (for example, a Bash script could use it).
 
 But if you absolutely need to ask for interactive information without using a *CLI option*, you can use `typer.prompt()`:

--- a/docs/tutorial/subcommands/add-typer.md
+++ b/docs/tutorial/subcommands/add-typer.md
@@ -1,3 +1,5 @@
+# Add Typer
+
 We'll start with the core idea.
 
 To add a `typer.Typer()` app inside of another.

--- a/docs/tutorial/subcommands/callback-override.md
+++ b/docs/tutorial/subcommands/callback-override.md
@@ -1,3 +1,5 @@
+# Sub-Typer Callback Override
+
 When creating a **Typer** app you can define a callback function, it always executes and defines the *CLI arguments* and *CLI options* that go before a command.
 
 When adding a Typer app inside of another, the sub-Typer can also have its own callback.

--- a/docs/tutorial/subcommands/index.md
+++ b/docs/tutorial/subcommands/index.md
@@ -1,3 +1,5 @@
+# SubCommands - Command Groups
+
 You read before how to create a program with [Commands](../commands/index.md){.internal-link target=_blank}.
 
 Now we'll see how to create a *CLI program* with commands that have their own subcommands. Also known as command groups.

--- a/docs/tutorial/subcommands/name-and-help.md
+++ b/docs/tutorial/subcommands/name-and-help.md
@@ -1,3 +1,5 @@
+# SubCommand Name and Help
+
 When adding a Typer app to another we have seen how to set the `name` to use for the command.
 
 For example to set the command to `users`:

--- a/docs/tutorial/subcommands/nested-subcommands.md
+++ b/docs/tutorial/subcommands/nested-subcommands.md
@@ -1,3 +1,5 @@
+# Nested SubCommands
+
 We'll now see how these same ideas can be extended for deeply nested commands.
 
 Let's imagine that the same *CLI program* from the previous examples now needs to handle `lands`.

--- a/docs/tutorial/subcommands/single-file.md
+++ b/docs/tutorial/subcommands/single-file.md
@@ -1,3 +1,5 @@
+# SubCommands in a Single File
+
 In some cases, it's possible that your application code needs to live on a single file.
 
 You can still use the same ideas:

--- a/docs/tutorial/terminating.md
+++ b/docs/tutorial/terminating.md
@@ -1,3 +1,5 @@
+# Terminating
+
 There are some cases where you might want to terminate a command at some point, and stop all subsequent execution.
 
 It could be that your code determined that the program completed successfully, or it could be an operation aborted.

--- a/docs/tutorial/testing.md
+++ b/docs/tutorial/testing.md
@@ -1,3 +1,5 @@
+# Testing
+
 Testing **Typer** applications is very easy with <a href="https://docs.pytest.org/en/latest/" class="external-link" target="_blank">pytest</a>.
 
 Let's say you have an application `app/main.py` with:

--- a/docs/tutorial/using-click.md
+++ b/docs/tutorial/using-click.md
@@ -1,3 +1,5 @@
+# Using Click
+
 /// warning
 
 This is a more advanced topic, if you are starting with **Typer**, feel free to skip it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,73 +52,73 @@ plugins:
 
 nav:
   - Typer: index.md
-  - Features: features.md
+  - features.md
   - Tutorial - User Guide:
-      - Tutorial - User Guide - Intro: tutorial/index.md
-      - First Steps: tutorial/first-steps.md
-      - Printing and Colors: tutorial/printing.md
-      - Terminating: tutorial/terminating.md
+      - tutorial/index.md
+      - tutorial/first-steps.md
+      - tutorial/printing.md
+      - tutorial/terminating.md
       - CLI Arguments:
-          - CLI Arguments Intro: tutorial/arguments/index.md
-          - Optional CLI Arguments: tutorial/arguments/optional.md
-          - CLI Arguments with Default: tutorial/arguments/default.md
-          - CLI Arguments with Help: tutorial/arguments/help.md
-          - CLI Arguments with Environment Variables: tutorial/arguments/envvar.md
-          - Other uses: tutorial/arguments/other-uses.md
+          - tutorial/arguments/index.md
+          - tutorial/arguments/optional.md
+          - tutorial/arguments/default.md
+          - tutorial/arguments/help.md
+          - tutorial/arguments/envvar.md
+          - tutorial/arguments/other-uses.md
       - CLI Options:
-          - CLI Options Intro: tutorial/options/index.md
-          - CLI Options with Help: tutorial/options/help.md
-          - Required CLI Options: tutorial/options/required.md
-          - CLI Option Prompt: tutorial/options/prompt.md
-          - Password CLI Option and Confirmation Prompt: tutorial/options/password.md
-          - CLI Option Name: tutorial/options/name.md
-          - CLI Option Callback and Context: tutorial/options/callback-and-context.md
-          - Version CLI Option, is_eager: tutorial/options/version.md
+          - tutorial/options/index.md
+          - tutorial/options/help.md
+          - tutorial/options/required.md
+          - tutorial/options/prompt.md
+          - tutorial/options/password.md
+          - tutorial/options/name.md
+          - tutorial/options/callback-and-context.md
+          - tutorial/options/version.md
       - Commands:
-          - Commands Intro: tutorial/commands/index.md
-          - Command CLI Arguments: tutorial/commands/arguments.md
-          - Command CLI Options: tutorial/commands/options.md
-          - Command Help: tutorial/commands/help.md
-          - Custom Command Name: tutorial/commands/name.md
-          - Typer Callback: tutorial/commands/callback.md
-          - One or Multiple Commands: tutorial/commands/one-or-multiple.md
-          - Using the Context: tutorial/commands/context.md
-      - CLI Option autocompletion: tutorial/options-autocompletion.md
+          - tutorial/commands/index.md
+          - tutorial/commands/arguments.md
+          - tutorial/commands/options.md
+          - tutorial/commands/help.md
+          - tutorial/commands/name.md
+          - tutorial/commands/callback.md
+          - tutorial/commands/one-or-multiple.md
+          - tutorial/commands/context.md
+      - tutorial/options-autocompletion.md
       - CLI Parameter Types:
-          - CLI Parameter Types Intro: tutorial/parameter-types/index.md
-          - Number: tutorial/parameter-types/number.md
-          - Boolean CLI Options: tutorial/parameter-types/bool.md
-          - UUID: tutorial/parameter-types/uuid.md
-          - DateTime: tutorial/parameter-types/datetime.md
-          - Enum - Choices: tutorial/parameter-types/enum.md
-          - Path: tutorial/parameter-types/path.md
-          - File: tutorial/parameter-types/file.md
-          - Custom Types: tutorial/parameter-types/custom-types.md
+          - tutorial/parameter-types/index.md
+          - tutorial/parameter-types/number.md
+          - tutorial/parameter-types/bool.md
+          - tutorial/parameter-types/uuid.md
+          - tutorial/parameter-types/datetime.md
+          - tutorial/parameter-types/enum.md
+          - tutorial/parameter-types/path.md
+          - tutorial/parameter-types/file.md
+          - tutorial/parameter-types/custom-types.md
       - SubCommands - Command Groups:
-          - SubCommands - Command Groups - Intro: tutorial/subcommands/index.md
-          - Add Typer: tutorial/subcommands/add-typer.md
-          - SubCommands in a Single File: tutorial/subcommands/single-file.md
-          - Nested SubCommands: tutorial/subcommands/nested-subcommands.md
-          - Sub-Typer Callback Override: tutorial/subcommands/callback-override.md
-          - SubCommand Name and Help: tutorial/subcommands/name-and-help.md
+          - tutorial/subcommands/index.md
+          - tutorial/subcommands/add-typer.md
+          - tutorial/subcommands/single-file.md
+          - tutorial/subcommands/nested-subcommands.md
+          - tutorial/subcommands/callback-override.md
+          - tutorial/subcommands/name-and-help.md
       - Multiple Values:
-          - Multiple Values Intro: tutorial/multiple-values/index.md
-          - Multiple CLI Options: tutorial/multiple-values/multiple-options.md
-          - CLI Options with Multiple Values: tutorial/multiple-values/options-with-multiple-values.md
-          - CLI Arguments with Multiple Values: tutorial/multiple-values/arguments-with-multiple-values.md
-      - Ask with Prompt: tutorial/prompt.md
-      - Progress Bar: tutorial/progressbar.md
-      - CLI Application Directory: tutorial/app-dir.md
-      - Launching Applications: tutorial/launch.md
-      - Testing: tutorial/testing.md
-      - Using Click: tutorial/using-click.md
-      - Building a Package: tutorial/package.md
+          - tutorial/multiple-values/index.md
+          - tutorial/multiple-values/multiple-options.md
+          - tutorial/multiple-values/options-with-multiple-values.md
+          - tutorial/multiple-values/arguments-with-multiple-values.md
+      - tutorial/prompt.md
+      - tutorial/progressbar.md
+      - tutorial/app-dir.md
+      - tutorial/launch.md
+      - tutorial/testing.md
+      - tutorial/using-click.md
+      - tutorial/package.md
       - tutorial/exceptions.md
       - tutorial/typer-command.md
-  - Alternatives, Inspiration and Comparisons: alternatives.md
-  - Help Typer - Get Help: help-typer.md
-  - Development - Contributing: contributing.md
-  - Release Notes: release-notes.md
+  - alternatives.md
+  - help-typer.md
+  - contributing.md
+  - release-notes.md
 
 markdown_extensions:
   toc:


### PR DESCRIPTION
🔧 Update MkDocs to have titles in Markdown files instead of config